### PR TITLE
Fix public key cache issue from env

### DIFF
--- a/tests/integration/test_protocol_client_v1alpha1.py
+++ b/tests/integration/test_protocol_client_v1alpha1.py
@@ -2,8 +2,8 @@ from theoriq.api import AgentResponseV1alpha1, ProtocolClientV1alpha1
 
 
 def test_get_agent():
-    pc = ProtocolClientV1alpha1("http://localhost:8080")
-    agent = pc.get_agent("110b06ec141df9f1e147a1a2de446c302786d7a2e991a715b33d64a7f993e025")
+    pc = ProtocolClientV1alpha1("https://infinity.theoriq.ai")
+    agent = pc.get_agent("d1d0a2284fac534d360d741a504928f15c994aeb339c2c498f68057baa628b4c")
     assert isinstance(agent, AgentResponseV1alpha1)
 
 
@@ -17,6 +17,16 @@ def test_get_agents():
 
 
 def test_get_public_key():
-    pc = ProtocolClientV1alpha1("http://localhost:8080")
+    pc = ProtocolClientV1alpha1("https://infinity.theoriq.ai")
     pub_key = pc.get_public_key()
     assert pub_key.key_type == "ed25519"
+
+
+def test_cached_public_key():
+    pc = ProtocolClientV1alpha1("https://infinity.theoriq.ai")
+    pub_key = pc.public_key
+    assert pub_key.startswith("0x")
+
+    pc = ProtocolClientV1alpha1("https://infinity.theoriq.ai")
+    pub_key = pc.public_key
+    assert pub_key.startswith("0x")

--- a/tests/unit/test_flask_v1alpha1.py
+++ b/tests/unit/test_flask_v1alpha1.py
@@ -59,7 +59,7 @@ def test_send_execute_request(
 ):
 
     with OsEnviron("THEORIQ_URI", "http://mock_flask_test"):
-        from_address = AgentAddress("0x012345689abcdef0123456789abcdef012345689abcdef0123456789abcdef01")
+        from_address = AgentAddress.random()
         req_body_bytes = _build_request_body_bytes("My name is John Doe", from_address)
         request_facts = new_request_facts(req_body_bytes, from_address, agent_config.address, 10)
         req_biscuit = new_biscuit_for_request(request_facts, theoriq_private_key)

--- a/theoriq/utils.py
+++ b/theoriq/utils.py
@@ -15,7 +15,7 @@ T = TypeVar("T")
 
 
 class TTLCache(Generic[T]):
-    def __init__(self, ttl: int, max_size: int):
+    def __init__(self, *, ttl: Optional[int] = None, max_size: int = 100):
         """
         Initialize the cache with a specific time-to-live (TTL) and maximum size.
 
@@ -24,7 +24,7 @@ class TTLCache(Generic[T]):
         """
         self.ttl = ttl
         self.max_size = max_size
-        self.cache: OrderedDict[str, tuple[T, float]] = OrderedDict()  # Cache storing (value, expiry_time)
+        self.cache: OrderedDict[str, tuple[T, Optional[float]]] = OrderedDict()  # Cache storing (value, expiry_time)
 
     def set(self, key: str, value: T) -> None:
         """
@@ -36,7 +36,7 @@ class TTLCache(Generic[T]):
         if key in self.cache:
             del self.cache[key]
 
-        expiry_time = time.time() + self.ttl
+        expiry_time = time.time() + self.ttl if self.ttl is not None else None
         self.cache[key] = (value, expiry_time)
 
         if len(self.cache) > self.max_size:
@@ -51,7 +51,7 @@ class TTLCache(Generic[T]):
         """
         if key in self.cache:
             value, expiry_time = self.cache[key]
-            if time.time() < expiry_time:
+            if expiry_time is None or time.time() < expiry_time:
                 return value
             else:
                 del self.cache[key]


### PR DESCRIPTION
The pub key cached value was invalidated by the `from_env()` call in the blueprint flask context