### PR TITLE
feat(configure-async): add AgentConfigurator

### DIFF
--- a/theoriq/api/v1alpha2/configure.py
+++ b/theoriq/api/v1alpha2/configure.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Callable
 
 from theoriq import Agent
@@ -19,7 +18,7 @@ class ConfigureContext:
         return self._agent.virtual_address
 
 
-ConfigureFn = Callable[[ConfigureContext, ...], None]
+ConfigureFn = Callable[[ConfigureContext, Any], None]
 """A callable type for the configuration function.
 
 The function accepts:
@@ -27,7 +26,7 @@ The function accepts:
 - Additional keyword arguments to build the configuration.
 """
 
-IsLongRunningFn = Callable[[ConfigureContext, ...], bool]
+IsLongRunningFn = Callable[[ConfigureContext, Any], bool]
 """A callable type for checking if a configuration is long-running.
 
 :param
@@ -54,7 +53,11 @@ class AgentConfigurator:
         Creates a default instance of AgentConfigurator.
         Useful when the agent does not require any configuration.
         """
-        def default_configure_fn(context, config): return None
-        def default_is_long_running_fn(context, config): return False
+
+        def default_configure_fn(context, config):
+            return None
+
+        def default_is_long_running_fn(context, config):
+            return False
 
         return cls(default_configure_fn, default_is_long_running_fn)

--- a/theoriq/api/v1alpha2/configure.py
+++ b/theoriq/api/v1alpha2/configure.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, Callable
 
 from theoriq import Agent
@@ -18,4 +19,42 @@ class ConfigureContext:
         return self._agent.virtual_address
 
 
-ConfigureFn = Callable[[ConfigureContext, Any], None]
+ConfigureFn = Callable[[ConfigureContext, ...], None]
+"""A callable type for the configuration function.
+
+The function accepts:
+- A `ConfigureContext` instance to provide the configuration context.
+- Additional keyword arguments to build the configuration.
+"""
+
+IsLongRunningFn = Callable[[ConfigureContext, ...], bool]
+"""A callable type for checking if a configuration is long-running.
+
+:param
+- A `ConfigureContext` instance to provide the configuration context.
+- Additional keyword arguments to build the configuration.
+
+:returns
+- A boolean indicating whether the configuration is long-running.
+"""
+
+
+class AgentConfigurator:
+    """
+    A class to manage and execute configuration for agents.
+    """
+
+    def __init__(self, configure_fn: ConfigureFn, is_long_running_fn: IsLongRunningFn) -> None:
+        self.configure_fn = configure_fn
+        self.is_long_running_fn = is_long_running_fn
+
+    @classmethod
+    def default(cls) -> "AgentConfigurator":
+        """
+        Creates a default instance of AgentConfigurator.
+        Useful when the agent does not require any configuration.
+        """
+        def default_configure_fn(context, config): return None
+        def default_is_long_running_fn(context, config): return False
+
+        return cls(default_configure_fn, default_is_long_running_fn)

--- a/theoriq/extra/flask/v1alpha2/flask.py
+++ b/theoriq/extra/flask/v1alpha2/flask.py
@@ -81,9 +81,7 @@ def theoriq_configuration_blueprint(agent_configurator: AgentConfigurator) -> Bl
     return blueprint
 
 
-def _build_v1alpha2_blueprint(
-    execute_fn: ExecuteRequestFnV1alpha2, agent_configurator: AgentConfigurator
-) -> Blueprint:
+def _build_v1alpha2_blueprint(execute_fn: ExecuteRequestFnV1alpha2, agent_configurator: AgentConfigurator) -> Blueprint:
     v1alpha2_blueprint = Blueprint("v1alpha2", __name__, url_prefix="/api/v1alpha2")
     v1alpha2_blueprint.add_url_rule("/execute", view_func=lambda: execute_v1alpha2(execute_fn), methods=["POST"])
     v1alpha2_blueprint.register_blueprint(theoriq_system_blueprint())


### PR DESCRIPTION
### Summary

The `AgentConfigurator` enables the specification of two functions: `is_long_running_fn` and `configure_fn`. These functions determine how an Agent's configuration should be executed. This marks the initial step toward supporting long-running configurations for agents.