### PR TITLE
feat(configure-async): verify configure request

### DIFF
--- a/theoriq/agent.py
+++ b/theoriq/agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Dict, Optional
 

--- a/theoriq/agent.py
+++ b/theoriq/agent.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 from typing import Any, Dict, Optional
 
@@ -20,6 +19,7 @@ from .biscuit import (
     VerificationError,
 )
 from .biscuit.payload_hash import PayloadHash
+from .biscuit.theoriq_biscuit import TheoriqBiscuit, TheoriqFact
 
 
 class AgentConfigurationSchemaError(Exception):
@@ -83,7 +83,7 @@ class Agent:
         :raises ParseBiscuitError: if the biscuit could not be parsed.
         :raises VerificationError: if the biscuit is not valid.
         """
-        self._authorize_biscuit(request_biscuit.biscuit)
+        self.authorize_biscuit(request_biscuit.biscuit)
         self._verify_biscuit_facts(request_biscuit.request_facts, body)
 
     def attenuate_biscuit_for_response(
@@ -91,7 +91,10 @@ class Agent:
     ) -> ResponseBiscuit:
         return req_biscuit.attenuate_for_response(body, cost, self.config.private_key)
 
-    def _authorize_biscuit(self, biscuit: Biscuit):
+    def attenuate_biscuit(self, biscuit: TheoriqBiscuit, fact: TheoriqFact) -> TheoriqBiscuit:
+        return biscuit.attenuate(self.config.private_key, fact)
+
+    def authorize_biscuit(self, biscuit: Biscuit):
         """Runs the authorization checks and policies on the given biscuit."""
         authorizer = self.config.address.default_authorizer()
         authorizer.add_token(biscuit)

--- a/theoriq/biscuit/__init__.py
+++ b/theoriq/biscuit/__init__.py
@@ -5,3 +5,4 @@ from .error import TheoriqBiscuitError, AuthorizationError, ParseBiscuitError, V
 from .response_biscuit import ResponseBiscuit, ResponseFacts
 from .request_biscuit import RequestBiscuit, RequestFacts
 from .utils import get_new_key_pair
+from .theoriq_biscuit import RequestFact, ResponseFact, TheoriqBiscuit

--- a/theoriq/biscuit/theoriq_biscuit.py
+++ b/theoriq/biscuit/theoriq_biscuit.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import abc
+from uuid import UUID
+from biscuit_auth import Authorizer, Biscuit, BlockBuilder, Fact, KeyPair, PrivateKey, PublicKey, Rule
+
+from theoriq.biscuit.agent_address import AgentAddress
+from theoriq.biscuit.utils import verify_address, from_base64_token
+from theoriq.types.currency import Currency
+from theoriq.biscuit import PayloadHash
+
+
+class TheoriqFact(abc.ABC):
+    """Base class for facts contained in a biscuit"""
+
+    @classmethod
+    def from_biscuit(cls, biscuit: Biscuit) -> "TheoriqFact":
+        """Extract facts from a biscuit"""
+        rule = cls.biscuit_rule()
+
+        authorizer = Authorizer()
+        authorizer.add_token(biscuit)
+        facts = authorizer.query(rule)
+
+        if len(facts) == 0:
+            raise ValueError("No facts found in current biscuit")
+
+        try:
+            return cls.from_fact(facts[0])
+        except Exception as e:
+            raise ValueError("Missing information") from e
+
+    @classmethod
+    @abc.abstractmethod
+    def biscuit_rule(cls) -> Rule:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def from_fact(cls, fact: Fact) -> "TheoriqFact":
+        pass
+
+    @abc.abstractmethod
+    def to_block_builder(self) -> BlockBuilder:
+        """Convert facts to a biscuit block"""
+        pass
+
+
+class RequestFact(TheoriqFact):
+    """`theoriq:request` fact"""
+
+    def __init__(self, request_id: UUID, body_hash, from_addr: str | AgentAddress, to_addr: str) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.body_hash = body_hash
+        self.from_addr = from_addr if isinstance(from_addr, str) else from_addr.address
+        self.to_addr = verify_address(to_addr)
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule("data($req_id, $body_hash, $from_addr, $target_addr) <- theoriq:request($req_id, $body_hash, $from_addr, $target_addr)")
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> "TheoriqFact":
+        [req_id, body_hash, from_addr, to_addr] = fact.terms
+        return cls(req_id, body_hash, from_addr, to_addr)
+
+    def to_block_builder(self) -> BlockBuilder:
+        fact = Fact(
+            "theoriq:request({req_id}, {body_hash}, {from_addr}, {to_addr})",
+            {
+                "req_id": str(self.request_id),
+                "body_hash": str(self.body_hash),
+                "from_addr": self.from_addr,
+                "to_addr": self.to_addr,
+            },
+        )
+
+        block_builder = BlockBuilder("")
+        block_builder.add_fact(fact)
+        return block_builder
+
+class BudgetFact(TheoriqFact):
+    """`theoriq:budget` fact"""
+
+    def __init__(self, request_id: UUID, amount: str | int, currency: Currency, voucher: str):
+        super().__init__()
+        self.request_id = request_id
+        self.amount = str(amount)
+        if len(self.amount) > 0 and currency is None:
+            raise ValueError("Invalid budget: currency must be specified if amount is specified")
+        self.currency = currency
+        self.voucher = voucher
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule("data($req_id, $amount, $currency, $voucher) <- theoriq:budget($req_id, $amount, $currency, $voucher)")
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> "TheoriqFact":
+        [req_id, amount, currency, voucher] = fact.terms
+        return cls(req_id, amount, currency, voucher)
+
+    def to_block_builder(self) -> BlockBuilder:
+        fact = Fact(
+            "theoriq:budget({req_id}, {amount}, {currency}, {voucher})",
+            {
+                "req_id": self.request_id,
+                "amount": self.amount,
+                "currency": self.currency.value if self.currency else "",
+                "voucher": self.voucher,
+            },
+        )
+
+        block_builder = BlockBuilder("")
+        block_builder.add_fact(fact)
+        return block_builder
+
+
+class ResponseFact(TheoriqFact):
+    """`theoriq:response` fact"""
+
+    def __init__(self, request_id: UUID, body_hash: PayloadHash, to_addr: str) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self._body_hash = body_hash
+        self.to_addr = to_addr
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule("data($req_id, $body_hash, $target_addr) <- theoriq:response($req_id, $body_hash, $target_addr)")
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> "TheoriqFact":
+        [req_id, body_hash, to_addr] = fact.terms
+        return cls(req_id, body_hash, to_addr)
+
+    def to_block_builder(self) -> BlockBuilder:
+        fact = Fact(
+            "theoriq:response({req_id}, {body_hash}, {to_addr})",
+            {
+                "req_id": str(self.request_id),
+                "body_hash": str(self._body_hash),
+                "to_addr": self.to_addr
+            },
+        )
+
+        block_builder = BlockBuilder("")
+        block_builder.add_fact(fact)
+        return block_builder
+
+
+class CostFact(TheoriqFact):
+    """`theoriq:cost` fact"""
+
+    def __init__(self, request_id: UUID, amount: str | int, currency: Currency) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.amount = str(amount)
+        self.currency = currency
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule("data($req_id, $amount, $currency) <- theoriq:cost($req_id, $amount, $currency)")
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> "TheoriqFact":
+        [req_id, amount, currency] = fact.terms
+        return cls(req_id, amount, currency)
+
+    def to_block_builder(self) -> BlockBuilder:
+        fact = Fact(
+            "theoriq:cost({req_id}, {amount}, {currency})",
+            {
+                "req_id": str(self.request_id),
+                "amount": self.amount,
+                "currency": self.currency.value
+            },
+        )
+
+        block_builder = BlockBuilder("")
+        block_builder.add_fact(fact)
+        return block_builder
+
+
+class TheoriqBiscuit:
+    """Base class for biscuits used in Theoriq protocol"""
+
+    def __init__(self, biscuit: Biscuit) -> None:
+        self.biscuit = biscuit
+
+    @classmethod
+    def from_token(cls, token: str, public_key: str) -> "TheoriqBiscuit":
+        public_key = public_key.removeprefix("0x")
+        biscuit = from_base64_token(token, PublicKey.from_hex(public_key))
+        return cls(biscuit)
+
+    def to_base64(self) -> str:
+        return self.biscuit.to_base64()
+
+    def attenuate(self, agent_pk: PrivateKey, fact: TheoriqFact) -> "TheoriqBiscuit":
+        agent_kp = KeyPair.from_private_key(agent_pk)
+        block_builder = fact.to_block_builder()
+        attenuated_biscuit = self.biscuit.append_third_party_block(agent_kp, block_builder)  # type: ignore
+        return TheoriqBiscuit(attenuated_biscuit)

--- a/theoriq/biscuit/theoriq_biscuit.py
+++ b/theoriq/biscuit/theoriq_biscuit.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import abc
 from uuid import UUID
+
 from biscuit_auth import Authorizer, Biscuit, BlockBuilder, Fact, KeyPair, PrivateKey, PublicKey, Rule
 
-from theoriq.biscuit.agent_address import AgentAddress
-from theoriq.biscuit.utils import verify_address, from_base64_token
 from theoriq.biscuit import PayloadHash
+from theoriq.biscuit.agent_address import AgentAddress
+from theoriq.biscuit.utils import from_base64_token, verify_address
 
 
 class TheoriqFact(abc.ABC):

--- a/theoriq/extra/flask/v1alpha2/flask.py
+++ b/theoriq/extra/flask/v1alpha2/flask.py
@@ -14,8 +14,7 @@ from theoriq.api import ExecuteContextV1alpha2, ExecuteRequestFnV1alpha2
 from theoriq.api.v1alpha2 import ConfigureContext
 from theoriq.api.v1alpha2.configure import AgentConfigurator
 from theoriq.api.v1alpha2.schemas import ExecuteRequestBody
-from theoriq.biscuit import PayloadHash, TheoriqBiscuitError
-from theoriq.biscuit.theoriq_biscuit import RequestFact, ResponseFact, TheoriqBiscuit
+from theoriq.biscuit import PayloadHash, RequestFact, ResponseFact, TheoriqBiscuit, TheoriqBiscuitError
 from theoriq.extra.flask.common import get_bearer_token
 from theoriq.extra.globals import agent_var
 

--- a/theoriq/extra/flask/v1alpha2/flask.py
+++ b/theoriq/extra/flask/v1alpha2/flask.py
@@ -14,7 +14,9 @@ from theoriq.api import ExecuteContextV1alpha2, ExecuteRequestFnV1alpha2
 from theoriq.api.v1alpha2 import ConfigureContext
 from theoriq.api.v1alpha2.configure import AgentConfigurator
 from theoriq.api.v1alpha2.schemas import ExecuteRequestBody
-from theoriq.biscuit import TheoriqBiscuitError, PayloadHash
+from theoriq.biscuit import PayloadHash, TheoriqBiscuitError
+from theoriq.biscuit.theoriq_biscuit import RequestFact, ResponseFact, TheoriqBiscuit
+from theoriq.extra.flask.common import get_bearer_token
 from theoriq.extra.globals import agent_var
 
 from ...logging.execute_context import ExecuteLogContext
@@ -25,9 +27,6 @@ from ..common import (
     process_biscuit_request,
     theoriq_system_blueprint,
 )
-from theoriq.extra.flask.common import get_bearer_token
-from theoriq.biscuit.theoriq_biscuit import TheoriqBiscuit, ResponseFact
-from theoriq.biscuit.theoriq_biscuit import RequestFact
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Summary

- Introduce functionality to extract a single fact from a biscuit.
- Enable authorization of the request biscuit sent to the agent during configuration.
- Integrate a ResponseFact to attenuate the biscuit.

These updates to biscuit are designed to avoid modifying the existing codebase, ensuring no disruptions to current functionality. Subsequent PRs will address any required code updates.