### PR TITLE
fix(configure-async): post request success

### DIFF
--- a/theoriq/api/v1alpha2/configure.py
+++ b/theoriq/api/v1alpha2/configure.py
@@ -70,7 +70,7 @@ class AgentConfigurator:
             configured_agent_id = request_fact.from_addr
             message = f"Successfully configured agent {configured_agent_id}"
             logger.info(message)
-            configure_context.post_request_failure(biscuit, message)
+            configure_context.post_request_success(biscuit, message)
 
     @classmethod
     def default(cls) -> AgentConfigurator:


### PR DESCRIPTION
### Summary

Update the long-running configuration to send a success event for POST requests when the configuration succeeds. Previously, the code incorrectly triggered a failure event even when the configuration was successful.