### PR TITLE
feat: Add `attenuate_for_request` to `TheoriqBiscuit`

### DIFF
--- a/theoriq/api/v1alpha2/protocol/protocol_client.py
+++ b/theoriq/api/v1alpha2/protocol/protocol_client.py
@@ -83,7 +83,7 @@ class ProtocolClient:
                 self._config_cache.set(key, configuration)
             return configuration
 
-    def post_request(self, request_biscuit: RequestBiscuit, content: bytes, to_addr: str):
+    def post_request(self, request_biscuit: TheoriqBiscuit | RequestBiscuit, content: bytes, to_addr: str):
         url = f'{self._uri}/agents/{to_addr.removeprefix("0x")}/execute'
         headers = request_biscuit.to_headers()
         with httpx.Client(timeout=self._timeout) as client:

--- a/theoriq/biscuit/theoriq_biscuit.py
+++ b/theoriq/biscuit/theoriq_biscuit.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-from functools import reduce
 from typing import Any, Dict, Generic, TypeVar
 from uuid import UUID
 
@@ -10,6 +9,7 @@ from biscuit_auth import Authorizer, Biscuit, BlockBuilder, Fact, KeyPair, Priva
 from theoriq.biscuit import PayloadHash
 from theoriq.biscuit.agent_address import AgentAddress
 from theoriq.biscuit.utils import from_base64_token, verify_address
+from theoriq.types import Currency
 
 # Define a type variable
 T = TypeVar("T")

--- a/theoriq/biscuit/theoriq_biscuit.py
+++ b/theoriq/biscuit/theoriq_biscuit.py
@@ -143,7 +143,9 @@ class TheoriqBiscuit:
         attenuated_biscuit = self.biscuit.append_third_party_block(agent_kp, block_builder)  # type: ignore
         return TheoriqBiscuit(attenuated_biscuit)
 
-    def attenuate_for_request(self, agent_pk: PrivateKey, request_id: UUID, facts: list[FactConvertibleBase]) -> TheoriqBiscuit:
+    def attenuate_for_request(
+        self, agent_pk: PrivateKey, request_id: UUID, facts: list[FactConvertibleBase]
+    ) -> TheoriqBiscuit:
         agent_kp = KeyPair.from_private_key(agent_pk)
         request_id = str(request_id)
         block_builder = BlockBuilder("")

--- a/theoriq/biscuit/theoriq_biscuit.py
+++ b/theoriq/biscuit/theoriq_biscuit.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from functools import reduce
-
 import abc
+from functools import reduce
 from typing import Any, Dict, Generic, TypeVar
 from uuid import UUID
 
@@ -70,7 +69,8 @@ class BudgetFact(TheoriqFactBase):
 
     @classmethod
     def biscuit_rule(cls) -> Rule:
-        return Rule("data($req_id, $amount, $currency, $voucher) <- theoriq:budget($req_id, $amount, $currency, $voucher)"
+        return Rule(
+            "data($req_id, $amount, $currency, $voucher) <- theoriq:budget($req_id, $amount, $currency, $voucher)"
         )
 
     @classmethod
@@ -88,6 +88,7 @@ class BudgetFact(TheoriqFactBase):
                 "voucher": self.voucher,
             },
         )
+
 
 class RequestFact(TheoriqFactBase):
     """`theoriq:request` fact"""

--- a/theoriq/biscuit/theoriq_biscuit.py
+++ b/theoriq/biscuit/theoriq_biscuit.py
@@ -10,7 +10,6 @@ from theoriq.biscuit import PayloadHash
 from theoriq.biscuit.agent_address import AgentAddress
 from theoriq.biscuit.facts import FactConvertibleBase
 from theoriq.biscuit.utils import from_base64_token, verify_address
-from theoriq.types import Currency
 
 # Define a type variable
 T = TypeVar("T")

--- a/theoriq/biscuit/theoriq_biscuit.py
+++ b/theoriq/biscuit/theoriq_biscuit.py
@@ -147,9 +147,9 @@ class TheoriqBiscuit:
         self, agent_pk: PrivateKey, request_id: UUID, facts: list[FactConvertibleBase]
     ) -> TheoriqBiscuit:
         agent_kp = KeyPair.from_private_key(agent_pk)
-        request_id = str(request_id)
         block_builder = BlockBuilder("")
         for fact in facts:
-            block_builder.add_fact(fact.to_fact(request_id))
+            converted_fact = fact.to_fact(str(request_id))
+            block_builder.add_fact(converted_fact)
         attenuated_biscuit = self.biscuit.append_third_party_block(agent_kp, block_builder)  # type: ignore
         return TheoriqBiscuit(attenuated_biscuit)


### PR DESCRIPTION
Since the Budget fact is required for the synchronous Agent execution flow, this PR adds an abstraction on top of the Budget fact to make agent development easier; Agents can attenuate their biscuit using this fact to perform synchronous execution.