### PR TITLE
feat: add notifications sent from virtual agent

### DIFF
--- a/theoriq/agent.py
+++ b/theoriq/agent.py
@@ -76,7 +76,8 @@ class Agent:
         return self._schema
 
     def authentication_biscuit(self) -> AuthenticationBiscuit:
-        facts = AuthenticationFacts(self.config.address, self.config.private_key)
+        address = self.config.address if self.virtual_address.is_null else self.virtual_address
+        facts = AuthenticationFacts(address, self.config.private_key)
         return facts.to_authentication_biscuit()
 
     def verify_biscuit(self, request_biscuit: RequestBiscuit, body: bytes) -> None:

--- a/theoriq/api/v1alpha2/execute.py
+++ b/theoriq/api/v1alpha2/execute.py
@@ -69,7 +69,7 @@ class ExecuteContext(ExecuteContextBase):
         """
         Sends agent notification via the protocol client.
         """
-        biscuit = TheoriqBiscuit(self._request_biscuit.biscuit)
+        biscuit = self.agent_biscuit()
         self._protocol_client.post_notification(biscuit=biscuit, agent_id=self.agent_address, notification=notification)
 
     def send_request(self, blocks: Sequence[ItemBlock], budget: TheoriqBudget, to_addr: str) -> ExecuteResponse:


### PR DESCRIPTION
**ClickUp task:** CU-868cw6p3j

### Summary

Modify the authentication biscuit generation to dynamically set the subject based on whether the request is sent to a deployed or virtual agent. This enables proper authentication handling and allows sending notifications on behalf of a virtual agent when applicable.