### PR TITLE
feat: consolidate theoriq facts

### DIFF
--- a/theoriq/api/v1alpha2/configure.py
+++ b/theoriq/api/v1alpha2/configure.py
@@ -66,7 +66,7 @@ class AgentConfigurator:
             logger.error(f"Failed to configure agent: {e}")
             configure_context.post_request_failure(biscuit, str(e))
         else:
-            request_fact = RequestFact.from_biscuit(biscuit)
+            request_fact = biscuit.read_fact(RequestFact)
             configured_agent_id = request_fact.from_addr
             message = f"Successfully configured agent {configured_agent_id}"
             logger.info(message)

--- a/theoriq/api/v1alpha2/protocol/protocol_client.py
+++ b/theoriq/api/v1alpha2/protocol/protocol_client.py
@@ -118,7 +118,7 @@ class ProtocolClient:
     def _post_request_complete(
         self, biscuit: TheoriqBiscuit, response: Optional[str], agent: Agent, status: RequestStatus
     ) -> None:
-        request_fact = RequestFact.from_biscuit(biscuit)
+        request_fact = biscuit.read_fact(RequestFact)
         request_id = request_fact.request_id
         from_addr = request_fact.from_addr
         url = f"{self._uri}/requests/{request_id}/{status.value}"

--- a/theoriq/api/v1alpha2/protocol/protocol_client.py
+++ b/theoriq/api/v1alpha2/protocol/protocol_client.py
@@ -204,6 +204,6 @@ class ProtocolClient:
     ) -> TheoriqBiscuit:
         config_response = ConfigureResponse(response=response)
         response_bytes = config_response.model_dump_json().encode()
-        response_fact = ResponseFact(request_id, PayloadHash(response_bytes), from_addr)
+        response_fact = ResponseFact(request_id=request_id, body_hash=PayloadHash(response_bytes), to_addr=from_addr)
         biscuit = agent.attenuate_biscuit(biscuit, response_fact)
         return biscuit

--- a/theoriq/biscuit/__init__.py
+++ b/theoriq/biscuit/__init__.py
@@ -1,8 +1,8 @@
 from .agent_address import AgentAddress
 from .payload_hash import PayloadHash
-from .facts import TheoriqCost, TheoriqBudget, TheoriqResponse, TheoriqRequest
+from .facts import RequestFact, ResponseFact, TheoriqCost, TheoriqBudget, TheoriqResponse, TheoriqRequest
 from .error import TheoriqBiscuitError, AuthorizationError, ParseBiscuitError, VerificationError
+from .theoriq_biscuit import TheoriqBiscuit
 from .response_biscuit import ResponseBiscuit, ResponseFacts
 from .request_biscuit import RequestBiscuit, RequestFacts
 from .utils import get_new_key_pair
-from .theoriq_biscuit import RequestFact, ResponseFact, TheoriqBiscuit

--- a/theoriq/biscuit/facts.py
+++ b/theoriq/biscuit/facts.py
@@ -5,10 +5,12 @@ Theoriq biscuit facts
 from __future__ import annotations
 
 import abc
-from typing import Optional
+import itertools
+from typing import Generic, List, TypeVar
 from uuid import UUID
 
-from biscuit_auth import Fact  # pylint: disable=E0611
+from biscuit_auth import BlockBuilder, Fact, Rule  # pylint: disable=E0611
+from typing_extensions import Self
 
 from theoriq.types import Currency
 
@@ -17,15 +19,233 @@ from .payload_hash import PayloadHash
 from .utils import verify_address
 
 
-class FactConvertibleBase(abc.ABC):
+class TheoriqFactBase(abc.ABC):
+    """Base class for facts contained in a biscuit"""
+
+    @classmethod
     @abc.abstractmethod
-    def to_fact(self, request_id: str) -> Fact:
+    def biscuit_rule(cls) -> Rule:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def from_fact(cls, fact: Fact) -> Self:
+        pass
+
+    @abc.abstractmethod
+    def to_facts(self) -> List[Fact]:
+        pass
+
+    def to_block_builder(self) -> BlockBuilder:
+        """Convert facts to a biscuit block"""
+        block_builder = BlockBuilder("")
+        for fact in self.to_facts():
+            block_builder.add_fact(fact)
+        return block_builder
+
+
+class RequestFact(TheoriqFactBase):
+    """`theoriq:request` fact"""
+
+    def __init__(
+        self, *, request_id: UUID, body_hash: PayloadHash, from_addr: str | AgentAddress, to_addr: str
+    ) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.body_hash = body_hash
+        self.from_addr = from_addr if isinstance(from_addr, str) else from_addr.address
+        self.to_addr = verify_address(to_addr)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule(
+            "data($req_id, $body_hash, $from_addr, $target_addr) <- theoriq:request($req_id, $body_hash, $from_addr, $target_addr)"
+        )
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> Self:
+        [req_id, body_hash, from_addr, to_addr] = fact.terms
+        return cls(request_id=req_id, body_hash=body_hash, from_addr=from_addr, to_addr=to_addr)
+
+    def to_facts(self) -> List[Fact]:
+        fact = Fact(
+            "theoriq:request({req_id}, {body_hash}, {from_addr}, {to_addr})",
+            {
+                "req_id": str(self.request_id),
+                "body_hash": str(self.body_hash),
+                "from_addr": self.from_addr,
+                "to_addr": self.to_addr,
+            },
+        )
+        return [fact]
+
+
+class BudgetFact(TheoriqFactBase):
+    """`theoriq:budget` fact"""
+
+    def __init__(self, *, request_id: UUID, amount: str | int, currency: Currency | str, voucher: str) -> None:
+        self.request_id = request_id
+        self.amount = str(amount)
+        self.currency = currency if isinstance(currency, str) else currency.value
+        self.voucher = voucher
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule(
+            "data($req_id, $amount, $currency, $voucher) <- theoriq:budget($req_id, $amount, $currency, $voucher)"
+        )
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> BudgetFact:
+        [req_id, amount, currency, voucher] = fact.terms
+        return cls(request_id=req_id, amount=amount, currency=currency, voucher=voucher)
+
+    def to_facts(self) -> List[Fact]:
+        """Convert to a biscuit fact"""
+        fact = Fact(
+            "theoriq:budget({req_id}, {amount}, {currency}, {voucher})",
+            {
+                "req_id": str(self.request_id),
+                "amount": self.amount,
+                "currency": self.currency.value if self.currency else "",
+                "voucher": self.voucher,
+            },
+        )
+        return [fact]
+
+
+class ResponseFact(TheoriqFactBase):
+    """`theoriq:response` fact"""
+
+    def __init__(self, *, request_id: UUID, body_hash: PayloadHash, to_addr: str) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.body_hash = body_hash
+        self.to_addr = to_addr
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule("data($req_id, $body_hash, $target_addr) <- theoriq:response($req_id, $body_hash, $target_addr)")
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> ResponseFact:
+        [req_id, body_hash, to_addr] = fact.terms
+        return cls(request_id=req_id, body_hash=body_hash, to_addr=to_addr)
+
+    def to_facts(self) -> List[Fact]:
+        fact = Fact(
+            "theoriq:response({req_id}, {body_hash}, {to_addr})",
+            {"req_id": str(self.request_id), "body_hash": str(self.body_hash), "to_addr": self.to_addr},
+        )
+        return [fact]
+
+
+class CostFact(TheoriqFactBase):
+    """`theoriq:cost` fact"""
+
+    def __init__(self, *, request_id: UUID, amount: str | int, currency: Currency) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.amount = str(amount)
+        self.currency = currency
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule("data($req_id, $amount, $currency) <- theoriq:cost($req_id, $amount, $currency)")
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> CostFact:
+        [req_id, amount, currency] = fact.terms
+        return cls(request_id=req_id, amount=amount, currency=currency)
+
+    def to_facts(self) -> List[Fact]:
+        fact = Fact(
+            "theoriq:cost({req_id}, {amount}, {currency})",
+            {"req_id": str(self.request_id), "amount": self.amount, "currency": self.currency.value},
+        )
+        return [fact]
+
+
+class ExecuteRequestFacts(TheoriqFactBase):
+    """`theoriq:request` & `theoriq:budget` facts"""
+
+    def __init__(self, *, request: RequestFact, budget: BudgetFact) -> None:
+        assert request.request_id == budget.request_id
+        self.request = request
+        self.budget = budget
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule(
+            """
+            data($req_id, $body_hash, $from_addr, $target_addr, $amount, $currency, $voucher) <- theoriq:request($req_id, $body_hash, $from_addr, $target_addr), theoriq:budget($req_id, $amount, $currency, $voucher)
+            """
+        )
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> Self:
+        [req_id, body_hash, from_addr, to_addr, amount, currency, voucher] = fact.terms
+        request = RequestFact(request_id=req_id, body_hash=body_hash, from_addr=from_addr, to_addr=to_addr)
+        budget = BudgetFact(request_id=req_id, amount=amount, currency=currency, voucher=voucher)
+        return cls(request=request, budget=budget)
+
+    def to_facts(self) -> List[Fact]:
+        facts = [self.request.to_facts(), self.budget.to_facts()]
+        return list(itertools.chain.from_iterable(facts))
+
+
+class ExecuteResponseFacts(TheoriqFactBase):
+    """`theoriq:response` & `theoriq:cost` facts"""
+
+    def __init__(self, *, response: ResponseFact, cost: CostFact) -> None:
+        self.response = response
+        self.cost = cost
+
+    @classmethod
+    def biscuit_rule(cls) -> Rule:
+        return Rule(
+            """
+            data($req_id, $body_hash, $target_addr, $amount, $currency) <- theoriq:response($req_id, $body_hash, $target_addr), theoriq:cost($req_id, $amount, $currency)
+            """
+        )
+
+    @classmethod
+    def from_fact(cls, fact: Fact) -> Self:
+        [req_id, body_hash, to_addr, amount, currency] = fact.terms
+        response = ResponseFact(request_id=req_id, body_hash=body_hash, to_addr=to_addr)
+        cost = CostFact(request_id=req_id, amount=amount, currency=currency)
+        return cls(response=response, cost=cost)
+
+    def to_facts(self) -> List[Fact]:
+        facts = [self.response.to_facts(), self.cost.to_facts()]
+        return list(itertools.chain.from_iterable(facts))
+
+
+T = TypeVar("T", bound=TheoriqFactBase)
+
+
+class FactConvertibleBase(abc.ABC, Generic[T]):
+    @abc.abstractmethod
+    def to_theoriq_fact(self, request_id: UUID) -> T:
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def from_theoriq_fact(cls, theoriq_fact: T) -> Self:
         pass
 
 
-class TheoriqRequest(FactConvertibleBase):
-    """`theoriq:request` fact"""
-
+class TheoriqRequest(FactConvertibleBase[RequestFact]):
     def __init__(self, *, body_hash: PayloadHash, from_addr: str | AgentAddress, to_addr: str) -> None:
         self.body_hash = body_hash
         self.from_addr = from_addr if isinstance(from_addr, str) else from_addr.address
@@ -36,17 +256,14 @@ class TheoriqRequest(FactConvertibleBase):
             return self.__dict__ == other.__dict__
         return False
 
-    def to_fact(self, request_id: str) -> Fact:
-        """Convert to a biscuit fact"""
-        return Fact(
-            "theoriq:request({req_id}, {body_hash}, {from_addr}, {to_addr})",
-            {
-                "req_id": request_id,
-                "body_hash": str(self.body_hash),
-                "from_addr": self.from_addr,
-                "to_addr": self.to_addr,
-            },
+    def to_theoriq_fact(self, request_id: UUID) -> RequestFact:
+        return RequestFact(
+            request_id=request_id, body_hash=self.body_hash, from_addr=self.from_addr, to_addr=self.to_addr
         )
+
+    @classmethod
+    def from_theoriq_fact(cls, fact: RequestFact) -> TheoriqRequest:
+        return cls(body_hash=fact.body_hash, from_addr=fact.from_addr, to_addr=fact.to_addr)
 
     @classmethod
     def from_body(cls, body: bytes, from_addr: str | AgentAddress, to_addr: str) -> TheoriqRequest:
@@ -58,14 +275,11 @@ class TheoriqRequest(FactConvertibleBase):
         return f"TheoriqRequest(body_hash={self.body_hash}, from_addr={self.from_addr}, to_addr={self.to_addr})"
 
 
-class TheoriqBudget(FactConvertibleBase):
-    """`theoriq:budget` fact"""
+class TheoriqBudget(FactConvertibleBase[BudgetFact]):
 
-    def __init__(self, *, amount: str | int, currency: Optional[Currency] = None, voucher: str) -> None:
+    def __init__(self, *, amount: str | int, currency: Currency | str, voucher: str) -> None:
         self.amount = str(amount)
-        if len(self.amount) > 0 and currency is None:
-            raise ValueError("Invalid budget: currency must be specified if amount is specified")
-        self.currency = currency
+        self.currency: Currency = currency if isinstance(currency, Currency) else Currency(currency)
         self.voucher = voucher
 
     def __eq__(self, other: object) -> bool:
@@ -80,17 +294,12 @@ class TheoriqBudget(FactConvertibleBase):
         currency = self.currency.value if self.currency else None
         return f"TheoriqBudget(amount={self.amount}, currency={currency}, voucher={self.voucher})"
 
-    def to_fact(self, request_id: str) -> Fact:
-        """Convert to a biscuit fact"""
-        return Fact(
-            "theoriq:budget({req_id}, {amount}, {currency}, {voucher})",
-            {
-                "req_id": request_id,
-                "amount": self.amount,
-                "currency": self.currency.value if self.currency else "",
-                "voucher": self.voucher,
-            },
-        )
+    def to_theoriq_fact(self, request_id: UUID) -> BudgetFact:
+        return BudgetFact(request_id=request_id, amount=self.amount, currency=self.currency, voucher=self.voucher)
+
+    @classmethod
+    def from_theoriq_fact(cls, fact: BudgetFact) -> Self:
+        return cls(amount=fact.amount, currency=Currency(fact.currency), voucher=fact.voucher)
 
     @classmethod
     def from_amount(cls, *, amount: str | int, currency: Currency) -> TheoriqBudget:
@@ -102,12 +311,10 @@ class TheoriqBudget(FactConvertibleBase):
 
     @classmethod
     def from_voucher(cls, *, voucher: str) -> TheoriqBudget:
-        return cls(amount="", currency=None, voucher=voucher)
+        return cls(amount="", currency=Currency.USDC, voucher=voucher)
 
 
-class TheoriqResponse(FactConvertibleBase):
-    """`theoriq:response` fact"""
-
+class TheoriqResponse(FactConvertibleBase[ResponseFact]):
     def __init__(self, *, body_hash: PayloadHash, to_addr: str) -> None:
         self._body_hash = body_hash
         self.to_addr = to_addr
@@ -117,12 +324,12 @@ class TheoriqResponse(FactConvertibleBase):
             return self.__dict__ == other.__dict__
         return False
 
-    def to_fact(self, request_id: str | UUID) -> Fact:
-        """Convert to a biscuit fact"""
-        return Fact(
-            "theoriq:response({req_id}, {body_hash}, {to_addr})",
-            {"req_id": str(request_id), "body_hash": str(self._body_hash), "to_addr": self.to_addr},
-        )
+    def to_theoriq_fact(self, request_id: UUID) -> ResponseFact:
+        return ResponseFact(request_id=request_id, body_hash=self._body_hash, to_addr=self.to_addr)
+
+    @classmethod
+    def from_theoriq_fact(cls, fact: ResponseFact) -> Self:
+        return cls(body_hash=fact.body_hash, to_addr=fact.to_addr)
 
     def __str__(self):
         return f"TheoriqResponse(body_hash={self._body_hash}, to_addr={self.to_addr})"
@@ -134,14 +341,10 @@ class TheoriqResponse(FactConvertibleBase):
         return cls(body_hash=body_hash, to_addr=to_addr)
 
 
-class TheoriqCost(FactConvertibleBase):
-    """
-    Biscuit fact representing the cost for the execution of an 'execute' request.
-    """
-
-    def __init__(self, *, amount: str | int, currency: Currency) -> None:
+class TheoriqCost(FactConvertibleBase[CostFact]):
+    def __init__(self, *, amount: str | int, currency: str | Currency) -> None:
         self.amount = str(amount)
-        self.currency = currency
+        self.currency = currency if isinstance(currency, str) else currency.value
 
     @classmethod
     def zero(cls, currency: Currency) -> TheoriqCost:
@@ -153,12 +356,12 @@ class TheoriqCost(FactConvertibleBase):
             return self.__dict__ == other.__dict__
         return False
 
-    def to_fact(self, request_id: str | UUID) -> Fact:
-        """Convert to a biscuit fact"""
-        return Fact(
-            "theoriq:cost({req_id}, {amount}, {currency})",
-            {"req_id": str(request_id), "amount": self.amount, "currency": self.currency.value},
-        )
+    def to_theoriq_fact(self, request_id: UUID) -> CostFact:
+        return CostFact(request_id=request_id, amount=self.amount, currency=Currency(self.currency))
+
+    @classmethod
+    def from_theoriq_fact(cls, fact: CostFact) -> Self:
+        return cls(amount=fact.amount, currency=fact.currency)
 
     def __str__(self):
         return f"TheoriqCost(amount={self.amount}, currency={self.currency.value})"

--- a/theoriq/biscuit/facts.py
+++ b/theoriq/biscuit/facts.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import abc
 import itertools
-from typing import Generic, List, TypeVar
+from typing import Generic, TypeVar
 from uuid import UUID
 
 from biscuit_auth import BlockBuilder, Fact, Rule
@@ -33,7 +33,7 @@ class TheoriqFactBase(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def to_facts(self) -> List[Fact]:
+    def to_facts(self) -> list[Fact]:
         pass
 
     def to_block_builder(self) -> BlockBuilder:
@@ -96,7 +96,7 @@ class RequestFact(TheoriqFactBase):
         [req_id, body_hash, from_addr, to_addr] = fact.terms
         return cls(request_id=req_id, body_hash=body_hash, from_addr=from_addr, to_addr=to_addr)
 
-    def to_facts(self) -> List[Fact]:
+    def to_facts(self) -> list[Fact]:
         fact = Fact(
             "theoriq:request({req_id}, {body_hash}, {from_addr}, {to_addr})",
             {
@@ -134,7 +134,7 @@ class BudgetFact(TheoriqFactBase):
         [req_id, amount, currency, voucher] = fact.terms
         return cls(request_id=req_id, amount=amount, currency=currency, voucher=voucher)
 
-    def to_facts(self) -> List[Fact]:
+    def to_facts(self) -> list[Fact]:
         """Convert to a biscuit fact"""
         fact = Fact(
             "theoriq:budget({req_id}, {amount}, {currency}, {voucher})",
@@ -166,7 +166,7 @@ class ResponseFact(TheoriqFactBase):
         [req_id, body_hash, to_addr] = fact.terms
         return cls(request_id=req_id, body_hash=body_hash, to_addr=to_addr)
 
-    def to_facts(self) -> List[Fact]:
+    def to_facts(self) -> list[Fact]:
         fact = Fact(
             "theoriq:response({req_id}, {body_hash}, {to_addr})",
             {"req_id": str(self.request_id), "body_hash": str(self.body_hash), "to_addr": self.to_addr},
@@ -192,7 +192,7 @@ class CostFact(TheoriqFactBase):
         [req_id, amount, currency] = fact.terms
         return cls(request_id=req_id, amount=amount, currency=currency)
 
-    def to_facts(self) -> List[Fact]:
+    def to_facts(self) -> list[Fact]:
         fact = Fact(
             "theoriq:cost({req_id}, {amount}, {currency})",
             {"req_id": str(self.request_id), "amount": self.amount, "currency": self.currency},
@@ -223,7 +223,7 @@ class ExecuteRequestFacts(TheoriqFactBase):
         budget = BudgetFact(request_id=req_id, amount=amount, currency=currency, voucher=voucher)
         return cls(request=request, budget=budget)
 
-    def to_facts(self) -> List[Fact]:
+    def to_facts(self) -> list[Fact]:
         facts = [self.request.to_facts(), self.budget.to_facts()]
         return list(itertools.chain.from_iterable(facts))
 
@@ -250,7 +250,7 @@ class ExecuteResponseFacts(TheoriqFactBase):
         cost = CostFact(request_id=req_id, amount=amount, currency=currency)
         return cls(response=response, cost=cost)
 
-    def to_facts(self) -> List[Fact]:
+    def to_facts(self) -> list[Fact]:
         facts = [self.response.to_facts(), self.cost.to_facts()]
         return list(itertools.chain.from_iterable(facts))
 

--- a/theoriq/biscuit/theoriq_biscuit.py
+++ b/theoriq/biscuit/theoriq_biscuit.py
@@ -1,118 +1,14 @@
 from __future__ import annotations
 
-import abc
-from typing import Any, Dict, Generic, TypeVar
+from typing import Any, Dict, Type, TypeVar
 from uuid import UUID
 
-from biscuit_auth import Authorizer, Biscuit, BlockBuilder, Fact, KeyPair, PrivateKey, PublicKey, Rule
+from biscuit_auth import Authorizer, Biscuit, BlockBuilder, KeyPair, PrivateKey, PublicKey
 
-from theoriq.biscuit import PayloadHash
-from theoriq.biscuit.agent_address import AgentAddress
-from theoriq.biscuit.facts import FactConvertibleBase
-from theoriq.biscuit.utils import from_base64_token, verify_address
+from theoriq.biscuit.facts import FactConvertibleBase, TheoriqFactBase
+from theoriq.biscuit.utils import from_base64_token
 
-# Define a type variable
-T = TypeVar("T")
-
-
-class TheoriqFactBase(abc.ABC, Generic[T]):
-    """Base class for facts contained in a biscuit"""
-
-    @classmethod
-    def from_biscuit(cls, theoriq_biscuit: TheoriqBiscuit) -> T:
-        """Extract facts from a biscuit"""
-        rule = cls.biscuit_rule()
-
-        authorizer = Authorizer()
-        authorizer.add_token(theoriq_biscuit.biscuit)
-        facts = authorizer.query(rule)
-
-        if len(facts) == 0:
-            raise ValueError("No facts found in current biscuit")
-
-        try:
-            return cls.from_fact(facts[0])
-        except Exception as e:
-            raise ValueError("Missing information") from e
-
-    @classmethod
-    @abc.abstractmethod
-    def biscuit_rule(cls) -> Rule:
-        pass
-
-    @classmethod
-    @abc.abstractmethod
-    def from_fact(cls, fact: Fact) -> T:
-        pass
-
-    @abc.abstractmethod
-    def to_fact(self) -> Fact:
-        pass
-
-    def to_block_builder(self) -> BlockBuilder:
-        """Convert facts to a biscuit block"""
-        fact = self.to_fact()
-        block_builder = BlockBuilder("")
-        block_builder.add_fact(fact)
-        return block_builder
-
-
-class RequestFact(TheoriqFactBase):
-    """`theoriq:request` fact"""
-
-    def __init__(self, request_id: UUID, body_hash: PayloadHash, from_addr: str | AgentAddress, to_addr: str) -> None:
-        super().__init__()
-        self.request_id = request_id
-        self.body_hash = body_hash
-        self.from_addr = from_addr if isinstance(from_addr, str) else from_addr.address
-        self.to_addr = verify_address(to_addr)
-
-    @classmethod
-    def biscuit_rule(cls) -> Rule:
-        return Rule(
-            "data($req_id, $body_hash, $from_addr, $target_addr) <- theoriq:request($req_id, $body_hash, $from_addr, $target_addr)"
-        )
-
-    @classmethod
-    def from_fact(cls, fact: Fact) -> RequestFact:
-        [req_id, body_hash, from_addr, to_addr] = fact.terms
-        return cls(req_id, body_hash, from_addr, to_addr)
-
-    def to_fact(self) -> Fact:
-        return Fact(
-            "theoriq:request({req_id}, {body_hash}, {from_addr}, {to_addr})",
-            {
-                "req_id": str(self.request_id),
-                "body_hash": str(self.body_hash),
-                "from_addr": self.from_addr,
-                "to_addr": self.to_addr,
-            },
-        )
-
-
-class ResponseFact(TheoriqFactBase):
-    """`theoriq:response` fact"""
-
-    def __init__(self, request_id: UUID, body_hash: PayloadHash, to_addr: str) -> None:
-        super().__init__()
-        self.request_id = request_id
-        self._body_hash = body_hash
-        self.to_addr = to_addr
-
-    @classmethod
-    def biscuit_rule(cls) -> Rule:
-        return Rule("data($req_id, $body_hash, $target_addr) <- theoriq:response($req_id, $body_hash, $target_addr)")
-
-    @classmethod
-    def from_fact(cls, fact: Fact) -> ResponseFact:
-        [req_id, body_hash, to_addr] = fact.terms
-        return cls(req_id, body_hash, to_addr)
-
-    def to_fact(self) -> Fact:
-        return Fact(
-            "theoriq:response({req_id}, {body_hash}, {to_addr})",
-            {"req_id": str(self.request_id), "body_hash": str(self._body_hash), "to_addr": self.to_addr},
-        )
+T = TypeVar("T", bound=TheoriqFactBase)
 
 
 class TheoriqBiscuit:
@@ -148,7 +44,21 @@ class TheoriqBiscuit:
         agent_kp = KeyPair.from_private_key(agent_pk)
         block_builder = BlockBuilder("")
         for fact in facts:
-            converted_fact = fact.to_fact(str(request_id))
-            block_builder.add_fact(converted_fact)
+            theoriq_fact = fact.to_theoriq_fact(request_id)
+            block_builder.merge(theoriq_fact.to_block_builder())
         attenuated_biscuit = self.biscuit.append_third_party_block(agent_kp, block_builder)  # type: ignore
         return TheoriqBiscuit(attenuated_biscuit)
+
+    def authorizer(self) -> Authorizer:
+        authorizer = Authorizer()
+        authorizer.add_token(self.biscuit)
+        return authorizer
+
+    def read_fact(self, fact_type: Type[T]) -> T:
+        facts = self.authorizer().query(fact_type.biscuit_rule())
+        if len(facts) == 0:
+            raise ValueError("No facts found in current biscuit")
+        try:
+            return fact_type.from_fact(facts[0])
+        except Exception as e:
+            raise ValueError("Missing information") from e


### PR DESCRIPTION
**ClickUp task:** CU-868cty244

### Summary  

Consolidate Biscuit and facts within the SDK:  
- Introduce classes representing Biscuit facts (`RequestFact` → `theoriq:request`, `BudgetFact` → `theoriq:budget`, etc.).  
- Enhance the `TheoriqBiscuit` wrapper to standardize how facts are attenuated and read from a Biscuit.  
- Remove Biscuit-related logic from higher-level classes (`TheoriqRequest`, `TheoriqBudget`, etc.).  

The goal is to establish a single, consistent way to interact with Biscuits while introducing multiple layers of abstraction. With this approach, users no longer need to manage Biscuit facts directly—they interact only with their higher-level counterparts (e.g., working with `RequestFacts` instead of `RequestFact` and `BudgetFact`).  

This solution also ensures backward compatibility, requiring no changes for end users.  

While this is a significant first step in normalizing Biscuit handling within the SDK, further work is needed to extend this approach across the entire codebase (e.g., `AgentAddress` still interacts with Biscuit directly, but ideally, it should rely on `SubjectFact` instead).