### PR TITLE
fix(currency): update ctor and remove from_value

### DIFF
--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,7 +1,7 @@
 import pytest
 
 from theoriq.biscuit import AgentAddress
-from theoriq.types import SourceType
+from theoriq.types import Currency, SourceType
 
 valid_agent_address = [
     "0x48656c6c6f20776f726c642c2074686948656c6c6f20776f726c642c20746869",
@@ -54,3 +54,25 @@ def test__from_address__with_invalid_agent_address__raise_value_error():
     with pytest.raises(ValueError) as exception_info:
         SourceType.from_address(address)
     assert str(exception_info.value) == f"'{address}' is not a valid address"
+
+
+@pytest.mark.parametrize(
+    "value,currency",
+    [
+        ("USDC", Currency.USDC),
+        ("usdc", Currency.USDC),
+        ("USDT", Currency.USDT),
+        ("usdt", Currency.USDT),
+        ("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", Currency.USDC),
+        ("0xdAC17F958D2ee523a2206206994597C13D831ec7", Currency.USDT),
+    ],
+)
+def test__currency_ctor__with_valid_value__returns_currency(value, currency):
+    assert Currency(value) == currency
+
+
+@pytest.mark.parametrize("value", ["Toto", "0x12", ""])
+def test__currency_ctor__with_invalid_value__raise_value_error(value):
+    with pytest.raises(ValueError) as exception_info:
+        Currency(value)
+    assert str(exception_info.value) == f"'{value}' is not a valid Currency"

--- a/theoriq/types/currency.py
+++ b/theoriq/types/currency.py
@@ -8,18 +8,12 @@ class Currency(Enum):
     USDC = "USDC"
     USDT = "USDT"
 
-    @staticmethod
-    def from_value(value: Any):
-        try:
-            if isinstance(value, str):
-                if value.startswith("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"):
-                    return Currency.USDC
-                elif value.startswith("0xdAC17F958D2ee523a2206206994597C13D831ec7"):
-                    return Currency.USDT
-                return Currency(value)
-            elif isinstance(value, Currency):
-                return value
-            else:
-                raise ValueError(f"'{value}' is not a valid Currency")
-        except ValueError as e:
-            raise ValueError(f"'{value}' is not a valid Currency") from e
+    @classmethod
+    def _missing_(cls, value: Any):
+        if isinstance(value, str):
+            if value.startswith("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"):
+                return Currency.USDC
+            elif value.startswith("0xdAC17F958D2ee523a2206206994597C13D831ec7"):
+                return Currency.USDT
+
+            return cls.__members__.get(value.upper(), None)


### PR DESCRIPTION
**ClickUp task:** CU-868d20up0

### Summary

This PR refactors the `Currency` enum to simplify its usage and reduce API misuse. Instead of relying on a separate `from_value` method, we now implement the `_missing_` function. This allows the default constructor to handle string-to-enum conversions seamlessly, improving clarity and maintainability.  

- [X] Move `Currency.from_value` inside the `_missing_` function so that the default constructor naturally supports string-based lookups. 
- [X] Add unit tests to ensure correct behaviour when converting a `Currency` from a string.  