### PR TITLE
Feature int in logging

### DIFF
--- a/theoriq/extra/flask/logging.py
+++ b/theoriq/extra/flask/logging.py
@@ -1,12 +1,12 @@
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 from flask import Flask
 
 from ..logging import http_request_context, init
 
 
-def init_logging(app: Flask, level: Optional[str] = None):
+def init_logging(app: Flask, level: Optional[Union[str, int]] = None):
     init(level)
     app.before_request(http_request_context.before_request)
     app.after_request(http_request_context.after_request)

--- a/theoriq/extra/logging/log_utils.py
+++ b/theoriq/extra/logging/log_utils.py
@@ -1,11 +1,11 @@
 import logging
 import os
-from typing import Optional
+from typing import Optional, Union
 
 from . import execute_context, http_request_context
 
 
-def init(level: Optional[str]):
+def init(level: Optional[Union[str, int]]):
     effective_level = level or os.environ.get("LOGLEVEL", "INFO").upper()
     logging.basicConfig(
         level=effective_level,


### PR DESCRIPTION
Accept both str and int in `init_logging()` since logging.LEVELS are integers