### PR TITLE
Feature attenuate for user request

### DIFF
--- a/tests/integration/test_get_agents.py
+++ b/tests/integration/test_get_agents.py
@@ -37,4 +37,4 @@ def test_get_agents_with_manager() -> None:
     for agent in agents:
         if agent.system.owner_address == user_address:
             agent_private = manager.get_agent(agent.system.id)
-            assert agent_private.configuration.deployment
+            assert agent_private.configuration.deployment or agent_private.configuration.virtual

--- a/tests/integration/test_get_agents.py
+++ b/tests/integration/test_get_agents.py
@@ -37,4 +37,4 @@ def test_get_agents_with_manager() -> None:
     for agent in agents:
         if agent.system.owner_address == user_address:
             agent_private = manager.get_agent(agent.system.id)
-            assert agent_private.configuration.deployment or agent_private.configuration.virtual
+            assert agent_private.configuration.deployment

--- a/theoriq/api/v1alpha2/message.py
+++ b/theoriq/api/v1alpha2/message.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 import uuid
 from typing import Optional, Sequence
 
-from biscuit_auth import KeyPair, PrivateKey
+from biscuit_auth import PrivateKey
 
-from theoriq import AgentDeploymentConfiguration, ExecuteResponse
-from theoriq.biscuit import AgentAddress, TheoriqBudget, TheoriqRequest
+from theoriq import ExecuteResponse
+from theoriq.biscuit import TheoriqBudget, TheoriqRequest
 from theoriq.dialog import Dialog, DialogItem, ItemBlock
 
-from ...biscuit.utils import get_user_address_from_biscuit
 from ..common import RequestSenderBase
-from .protocol.biscuit_provider import BiscuitProvider, BiscuitProviderFactory, BiscuitProviderFromAPIKey
+from .protocol.biscuit_provider import (
+    BiscuitProvider,
+    BiscuitProviderFactory,
+    BiscuitProviderFromAPIKey,
+    BiscuitProviderFromPrivateKey,
+)
 from .protocol.protocol_client import ProtocolClient
 from .schemas.request import ExecuteRequestBody
 
@@ -19,20 +23,20 @@ from .schemas.request import ExecuteRequestBody
 class Messenger(RequestSenderBase):
     """Handles direct communications with other agents."""
 
-    def __init__(
-        self, private_key: PrivateKey, biscuit_provider: BiscuitProvider, client: Optional[ProtocolClient] = None
-    ) -> None:
+    def __init__(self, biscuit_provider: BiscuitProvider, client: Optional[ProtocolClient] = None) -> None:
         self._client = client or ProtocolClient.from_env()
         self._biscuit_provider = biscuit_provider
-        self._private_key = private_key
 
-        key_pair = KeyPair.from_private_key(self._private_key)
-        self._agent_address = AgentAddress.from_public_key(key_pair.public_key)
+        self._private_key: Optional[PrivateKey] = None
+        self._address: str
 
-        self._user_address: Optional[str] = None
         if isinstance(biscuit_provider, BiscuitProviderFromAPIKey):
-            theoriq_biscuit = biscuit_provider.get_biscuit()
-            self._user_address = get_user_address_from_biscuit(theoriq_biscuit.biscuit)
+            self._address = biscuit_provider._address
+        elif isinstance(biscuit_provider, BiscuitProviderFromPrivateKey):
+            self._private_key = biscuit_provider._key_pair.private_key
+            self._address = str(biscuit_provider._address)
+        else:
+            raise ValueError("Unknown BiscuitProvider")
 
     def send_request(self, blocks: Sequence[ItemBlock], budget: TheoriqBudget, to_addr: str) -> ExecuteResponse:
         """
@@ -46,12 +50,12 @@ class Messenger(RequestSenderBase):
         Returns:
             ExecuteResponse: The response received from the request.
         """
-        address: str = str(self._user_address or self._agent_address)
 
-        execute_request_body = ExecuteRequestBody(dialog=Dialog(items=[DialogItem.new(source=address, blocks=blocks)]))
+        dialog = Dialog(items=[DialogItem.new(source=self._address, blocks=blocks)])
+        execute_request_body = ExecuteRequestBody(dialog=dialog)
         body = execute_request_body.model_dump_json().encode("utf-8")
 
-        theoriq_request = TheoriqRequest.from_body(body=body, from_addr=address, to_addr=to_addr)
+        theoriq_request = TheoriqRequest.from_body(body=body, from_addr=self._address, to_addr=to_addr)
         theoriq_biscuit = self._biscuit_provider.get_biscuit()
         theoriq_biscuit = theoriq_biscuit.attenuate_for_request(
             agent_pk=self._private_key, request_id=uuid.uuid4(), facts=[theoriq_request, budget]
@@ -61,14 +65,8 @@ class Messenger(RequestSenderBase):
 
     @classmethod
     def from_api_key(cls, api_key: str) -> Messenger:
-        return Messenger(
-            # generating new private key as a placeholder, should use different attenuate function
-            private_key=KeyPair().private_key,
-            biscuit_provider=BiscuitProviderFactory.from_api_key(api_key=api_key),
-        )
+        return Messenger(biscuit_provider=BiscuitProviderFactory.from_api_key(api_key=api_key))
 
     @classmethod
     def from_env(cls, env_prefix: str = "") -> Messenger:
-        config = AgentDeploymentConfiguration.from_env(env_prefix=env_prefix)
-        biscuit_provider = BiscuitProviderFactory.from_env(env_prefix=env_prefix)
-        return Messenger(private_key=config.private_key, biscuit_provider=biscuit_provider)
+        return Messenger(biscuit_provider=BiscuitProviderFactory.from_env(env_prefix=env_prefix))

--- a/theoriq/api/v1alpha2/message.py
+++ b/theoriq/api/v1alpha2/message.py
@@ -3,19 +3,12 @@ from __future__ import annotations
 import uuid
 from typing import Optional, Sequence
 
-from biscuit_auth import PrivateKey
-
 from theoriq import ExecuteResponse
 from theoriq.biscuit import TheoriqBudget, TheoriqRequest
 from theoriq.dialog import Dialog, DialogItem, ItemBlock
 
 from ..common import RequestSenderBase
-from .protocol.biscuit_provider import (
-    BiscuitProvider,
-    BiscuitProviderFactory,
-    BiscuitProviderFromAPIKey,
-    BiscuitProviderFromPrivateKey,
-)
+from .protocol.biscuit_provider import BiscuitProvider, BiscuitProviderFactory
 from .protocol.protocol_client import ProtocolClient
 from .schemas.request import ExecuteRequestBody
 
@@ -26,17 +19,6 @@ class Messenger(RequestSenderBase):
     def __init__(self, biscuit_provider: BiscuitProvider, client: Optional[ProtocolClient] = None) -> None:
         self._client = client or ProtocolClient.from_env()
         self._biscuit_provider = biscuit_provider
-
-        self._private_key: Optional[PrivateKey] = None
-        self._address: str
-
-        if isinstance(biscuit_provider, BiscuitProviderFromAPIKey):
-            self._address = biscuit_provider._address
-        elif isinstance(biscuit_provider, BiscuitProviderFromPrivateKey):
-            self._private_key = biscuit_provider._key_pair.private_key
-            self._address = str(biscuit_provider._address)
-        else:
-            raise ValueError("Unknown BiscuitProvider")
 
     def send_request(self, blocks: Sequence[ItemBlock], budget: TheoriqBudget, to_addr: str) -> ExecuteResponse:
         """
@@ -51,14 +33,13 @@ class Messenger(RequestSenderBase):
             ExecuteResponse: The response received from the request.
         """
 
-        dialog = Dialog(items=[DialogItem.new(source=self._address, blocks=blocks)])
+        dialog = Dialog(items=[DialogItem.new(source=self._biscuit_provider.address, blocks=blocks)])
         execute_request_body = ExecuteRequestBody(dialog=dialog)
         body = execute_request_body.model_dump_json().encode("utf-8")
 
-        theoriq_request = TheoriqRequest.from_body(body=body, from_addr=self._address, to_addr=to_addr)
-        theoriq_biscuit = self._biscuit_provider.get_biscuit()
-        theoriq_biscuit = theoriq_biscuit.attenuate_for_request(
-            agent_pk=self._private_key, request_id=uuid.uuid4(), facts=[theoriq_request, budget]
+        theoriq_request = TheoriqRequest.from_body(body=body, from_addr=self._biscuit_provider.address, to_addr=to_addr)
+        theoriq_biscuit = self._biscuit_provider.get_request_biscuit(
+            request_id=uuid.uuid4(), facts=[theoriq_request, budget]
         )
         response = self._client.post_request(request_biscuit=theoriq_biscuit, content=body, to_addr=to_addr)
         return ExecuteResponse.from_protocol_response({"dialog_item": response}, 200)

--- a/theoriq/api/v1alpha2/protocol/biscuit_provider.py
+++ b/theoriq/api/v1alpha2/protocol/biscuit_provider.py
@@ -22,10 +22,12 @@ class BiscuitProvider(abc.ABC):
     @property
     @abc.abstractmethod
     def address(self) -> str:
+        """Get the address of the entity that issued the biscuit."""
         pass
 
     @abc.abstractmethod
     def _get_new_biscuit(self) -> Tuple[TheoriqBiscuit, int]:
+        """Get new biscuit and its expiration time."""
         pass
 
     @abc.abstractmethod

--- a/theoriq/api/v1alpha2/protocol/biscuit_provider.py
+++ b/theoriq/api/v1alpha2/protocol/biscuit_provider.py
@@ -10,6 +10,7 @@ from theoriq.api.v1alpha2 import ProtocolClient
 from theoriq.biscuit import AgentAddress, TheoriqBiscuit
 from theoriq.biscuit.authentication_biscuit import AuthenticationBiscuit, AuthenticationFacts
 from theoriq.biscuit.facts import ExpiresAtFact
+from theoriq.biscuit.utils import get_user_address_from_biscuit
 
 
 class BiscuitProvider(abc.ABC):
@@ -47,6 +48,7 @@ class BiscuitProviderFromAPIKey(BiscuitProvider):
     def __init__(self, api_key: str, client: ProtocolClient) -> None:
         super().__init__()
         self._api_key_biscuit = TheoriqBiscuit.from_token(token=api_key, public_key=client.public_key)
+        self._address = get_user_address_from_biscuit(self._api_key_biscuit.biscuit)
         self._client = client
 
     def _get_new_biscuit(self) -> Tuple[TheoriqBiscuit, int]:

--- a/theoriq/api/v1alpha2/protocol/biscuit_provider.py
+++ b/theoriq/api/v1alpha2/protocol/biscuit_provider.py
@@ -1,6 +1,7 @@
 import abc
 import time
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
+from uuid import UUID
 
 from biscuit_auth import PrivateKey
 from biscuit_auth.biscuit_auth import KeyPair
@@ -9,7 +10,7 @@ from theoriq import AgentDeploymentConfiguration
 from theoriq.api.v1alpha2 import ProtocolClient
 from theoriq.biscuit import AgentAddress, TheoriqBiscuit
 from theoriq.biscuit.authentication_biscuit import AuthenticationBiscuit, AuthenticationFacts
-from theoriq.biscuit.facts import ExpiresAtFact
+from theoriq.biscuit.facts import ExpiresAtFact, FactConvertibleBase
 from theoriq.biscuit.utils import get_user_address_from_biscuit
 
 
@@ -18,8 +19,18 @@ class BiscuitProvider(abc.ABC):
         self._biscuit: Optional[TheoriqBiscuit] = None
         self._renew_after: int = int(time.time())
 
+    @property
+    @abc.abstractmethod
+    def address(self) -> str:
+        pass
+
     @abc.abstractmethod
     def _get_new_biscuit(self) -> Tuple[TheoriqBiscuit, int]:
+        pass
+
+    @abc.abstractmethod
+    def get_request_biscuit(self, request_id: UUID, facts: Sequence[FactConvertibleBase]) -> TheoriqBiscuit:
+        """Get new biscuit attenuated for request."""
         pass
 
     def get_biscuit(self) -> TheoriqBiscuit:
@@ -36,12 +47,23 @@ class BiscuitProviderFromPrivateKey(BiscuitProvider):
         self._address: AgentAddress = address or AgentAddress.from_public_key(self._key_pair.public_key)
         self._client = client
 
+    @property
+    def address(self) -> str:
+        return str(self._address)
+
     def _get_new_biscuit(self) -> Tuple[TheoriqBiscuit, int]:
         facts = AuthenticationFacts(self._address, self._key_pair.private_key)
         authentication_biscuit = facts.to_authentication_biscuit()
         result = self._client.get_biscuit(authentication_biscuit, self._key_pair.public_key)
         biscuit = TheoriqBiscuit.from_token(token=result.biscuit, public_key=self._client.public_key)
         return biscuit, result.data.expires_at
+
+    def get_request_biscuit(self, request_id: UUID, facts: Sequence[FactConvertibleBase]) -> TheoriqBiscuit:
+        theoriq_biscuit = self.get_biscuit()
+        theoriq_biscuit = theoriq_biscuit.attenuate_for_request(
+            agent_pk=self._key_pair.private_key, request_id=request_id, facts=facts
+        )
+        return theoriq_biscuit
 
 
 class BiscuitProviderFromAPIKey(BiscuitProvider):
@@ -51,11 +73,20 @@ class BiscuitProviderFromAPIKey(BiscuitProvider):
         self._address = get_user_address_from_biscuit(self._api_key_biscuit.biscuit)
         self._client = client
 
+    @property
+    def address(self) -> str:
+        return self._address
+
     def _get_new_biscuit(self) -> Tuple[TheoriqBiscuit, int]:
         new_biscuit = self._api_key_biscuit.attenuate(ExpiresAtFact.from_lifetime_duration(300))
         result = self._client.api_key_exchange(AuthenticationBiscuit(new_biscuit.biscuit))
         biscuit = TheoriqBiscuit.from_token(token=result.biscuit, public_key=self._client.public_key)
         return biscuit, result.data.expires_at
+
+    def get_request_biscuit(self, request_id: UUID, facts: Sequence[FactConvertibleBase]) -> TheoriqBiscuit:
+        theoriq_biscuit = self.get_biscuit()
+        theoriq_biscuit = theoriq_biscuit.attenuate_for_request(agent_pk=None, request_id=request_id, facts=facts)
+        return theoriq_biscuit
 
 
 class BiscuitProviderFactory:

--- a/theoriq/biscuit/facts.py
+++ b/theoriq/biscuit/facts.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import abc
 import itertools
 import time
-from typing import Generic, TypeVar
+from typing import Generic, List, TypeVar
 from uuid import UUID
 
 from biscuit_auth import BlockBuilder, Fact, Rule
@@ -34,7 +34,7 @@ class TheoriqFactBase(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def to_facts(self) -> list[Fact]:
+    def to_facts(self) -> List[Fact]:
         pass
 
     def to_block_builder(self) -> BlockBuilder:
@@ -61,7 +61,7 @@ class ExpiresAtFact(TheoriqFactBase):
         [expires_at] = fact.terms
         return cls(expires_at=expires_at)
 
-    def to_facts(self) -> list[Fact]:
+    def to_facts(self) -> List[Fact]:
         fact = Fact("theoriq:expires_at({expires_at})", {"expires_at": self.expires_at})
         return [fact]
 
@@ -87,7 +87,7 @@ class SubjectFact(TheoriqFactBase):
         [address] = fact.terms
         return cls(agent_id=address)
 
-    def to_facts(self) -> list[Fact]:
+    def to_facts(self) -> List[Fact]:
         fact = Fact(
             """theoriq:subject("agent", {agent_id})""",
             {"agent_id": self.agent_id},
@@ -123,7 +123,7 @@ class RequestFact(TheoriqFactBase):
         [req_id, body_hash, from_addr, to_addr] = fact.terms
         return cls(request_id=req_id, body_hash=body_hash, from_addr=from_addr, to_addr=to_addr)
 
-    def to_facts(self) -> list[Fact]:
+    def to_facts(self) -> List[Fact]:
         fact = Fact(
             "theoriq:request({req_id}, {body_hash}, {from_addr}, {to_addr})",
             {
@@ -161,7 +161,7 @@ class BudgetFact(TheoriqFactBase):
         [req_id, amount, currency, voucher] = fact.terms
         return cls(request_id=req_id, amount=amount, currency=currency, voucher=voucher)
 
-    def to_facts(self) -> list[Fact]:
+    def to_facts(self) -> List[Fact]:
         """Convert to a biscuit fact"""
         fact = Fact(
             "theoriq:budget({req_id}, {amount}, {currency}, {voucher})",
@@ -193,7 +193,7 @@ class ResponseFact(TheoriqFactBase):
         [req_id, body_hash, to_addr] = fact.terms
         return cls(request_id=req_id, body_hash=body_hash, to_addr=to_addr)
 
-    def to_facts(self) -> list[Fact]:
+    def to_facts(self) -> List[Fact]:
         fact = Fact(
             "theoriq:response({req_id}, {body_hash}, {to_addr})",
             {"req_id": str(self.request_id), "body_hash": str(self.body_hash), "to_addr": self.to_addr},
@@ -219,7 +219,7 @@ class CostFact(TheoriqFactBase):
         [req_id, amount, currency] = fact.terms
         return cls(request_id=req_id, amount=amount, currency=currency)
 
-    def to_facts(self) -> list[Fact]:
+    def to_facts(self) -> List[Fact]:
         fact = Fact(
             "theoriq:cost({req_id}, {amount}, {currency})",
             {"req_id": str(self.request_id), "amount": self.amount, "currency": self.currency},
@@ -250,7 +250,7 @@ class ExecuteRequestFacts(TheoriqFactBase):
         budget = BudgetFact(request_id=req_id, amount=amount, currency=currency, voucher=voucher)
         return cls(request=request, budget=budget)
 
-    def to_facts(self) -> list[Fact]:
+    def to_facts(self) -> List[Fact]:
         facts = [self.request.to_facts(), self.budget.to_facts()]
         return list(itertools.chain.from_iterable(facts))
 
@@ -277,7 +277,7 @@ class ExecuteResponseFacts(TheoriqFactBase):
         cost = CostFact(request_id=req_id, amount=amount, currency=currency)
         return cls(response=response, cost=cost)
 
-    def to_facts(self) -> list[Fact]:
+    def to_facts(self) -> List[Fact]:
         facts = [self.response.to_facts(), self.cost.to_facts()]
         return list(itertools.chain.from_iterable(facts))
 


### PR DESCRIPTION
Make private key in `attenuate_for_request` optional, allowing for correct attenuation in user case
This cleans up `Messenger` implementation