### PR TITLE
Fix test_get_agents

### DIFF
--- a/tests/integration/test_get_agents.py
+++ b/tests/integration/test_get_agents.py
@@ -25,7 +25,7 @@ def test_get_agents_with_client() -> None:
 
     for agent in agents:
         assert isinstance(agent, AgentResponse)
-        assert agent.configuration.deployment is None and agent.configuration.virtual is None
+        assert agent.configuration.is_empty
 
 
 def test_get_agents_with_manager() -> None:
@@ -38,4 +38,4 @@ def test_get_agents_with_manager() -> None:
     for agent in agents:
         if agent.system.owner_address == user_address:
             agent_private = manager.get_agent(agent.system.id)
-            assert agent_private.configuration.deployment or agent_private.configuration.virtual
+            assert agent_private.configuration.is_valid

--- a/tests/integration/test_get_agents.py
+++ b/tests/integration/test_get_agents.py
@@ -25,6 +25,7 @@ def test_get_agents_with_client() -> None:
 
     for agent in agents:
         assert isinstance(agent, AgentResponse)
+        assert agent.configuration.deployment is None and agent.configuration.virtual is None
 
 
 def test_get_agents_with_manager() -> None:
@@ -37,4 +38,4 @@ def test_get_agents_with_manager() -> None:
     for agent in agents:
         if agent.system.owner_address == user_address:
             agent_private = manager.get_agent(agent.system.id)
-            assert agent_private.configuration.deployment
+            assert agent_private.configuration.deployment or agent_private.configuration.virtual

--- a/theoriq/api/v1alpha2/schemas/agent.py
+++ b/theoriq/api/v1alpha2/schemas/agent.py
@@ -41,6 +41,16 @@ class Configuration(BaseModel):
     deployment: Optional[Dict[str, Any]] = None
     virtual: Optional[Virtual] = Field(default=None)
 
+    @property
+    def is_valid(self) -> bool:
+        is_virtual = self.virtual is not None and self.deployment is None
+        is_deployed = self.virtual is None and self.deployment is not None
+        return is_virtual or is_deployed
+
+    @property
+    def is_empty(self) -> bool:
+        return self.virtual is None and self.deployment is None
+
     # noinspection PyNestedDecorators
     @field_validator("virtual", mode="before")
     @classmethod

--- a/theoriq/api/v1alpha2/schemas/agent.py
+++ b/theoriq/api/v1alpha2/schemas/agent.py
@@ -52,6 +52,15 @@ class Configuration(BaseModel):
             return Virtual(**value)
         return value
 
+    # noinspection PyNestedDecorators
+    @field_validator("deployment", mode="before")
+    @classmethod
+    def validate_deployment(cls, value: Any) -> Optional[Any]:
+        # Handle cases where `deployment` is an empty dict or None
+        if value is None or value == {}:
+            return None
+        return value
+
 
 class AgentResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)


### PR DESCRIPTION
Fix `test_get_agents.py`:
- Expect some configuration information for authenticated requests (with `AgentManager`) and no configuration information for not authenticated requests (with `ProtocolClient`)
- Add deployment `field_validator` to receive `None` instead of `{}`