### PR TITLE
Move Agent to v1alpha2

### DIFF
--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -7,7 +7,7 @@ import pytest
 from biscuit_auth import KeyPair, PrivateKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
-from theoriq.agent import AgentDeploymentConfiguration
+from theoriq.api.v1alpha2.agent import AgentDeploymentConfiguration
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -7,7 +7,7 @@ import pytest
 from biscuit_auth import KeyPair, PrivateKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
-from theoriq.api.v1alpha2.agent import AgentDeploymentConfiguration
+from theoriq import AgentDeploymentConfiguration
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/test_challenge.py
+++ b/tests/unit/test_challenge.py
@@ -2,7 +2,7 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from tests.unit.fixtures import *  # noqa: F403
 
-from theoriq.api.v1alpha2.agent import Agent, AgentDeploymentConfiguration
+from theoriq import Agent, AgentDeploymentConfiguration
 
 
 @pytest.fixture()

--- a/tests/unit/test_challenge.py
+++ b/tests/unit/test_challenge.py
@@ -2,7 +2,7 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from tests.unit.fixtures import *  # noqa: F403
 
-from theoriq.agent import Agent, AgentDeploymentConfiguration
+from theoriq.api.v1alpha2.agent import Agent, AgentDeploymentConfiguration
 
 
 @pytest.fixture()

--- a/tests/unit/test_flask_v1alpha2.py
+++ b/tests/unit/test_flask_v1alpha2.py
@@ -8,7 +8,7 @@ from flask import Flask
 from flask.testing import FlaskClient
 from tests.unit.fixtures import *  # noqa: F403
 
-from theoriq.agent import AgentDeploymentConfiguration
+from theoriq.api.v1alpha2.agent import AgentDeploymentConfiguration
 from theoriq.api.v1alpha2.execute import ExecuteContext, ExecuteResponse
 from theoriq.api.v1alpha2.schemas import ChallengeResponseBody, ExecuteRequestBody
 from theoriq.biscuit import AgentAddress, TheoriqCost

--- a/theoriq/__init__.py
+++ b/theoriq/__init__.py
@@ -1,4 +1,3 @@
-from .agent import AgentDeploymentConfiguration, Agent
-
+from .api.v1alpha2.agent import AgentDeploymentConfiguration, Agent
 from .api.v1alpha2.execute import ExecuteContext, ExecuteResponse
 from .api.common import ExecuteRuntimeError

--- a/theoriq/api/common.py
+++ b/theoriq/api/common.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import abc
 from typing import Any, Dict, Optional, Sequence
 
-from theoriq import Agent
-
 from ..biscuit import RequestBiscuit, ResponseBiscuit, TheoriqBudget, TheoriqCost
 from ..dialog import DialogItem, ErrorItemBlock, ItemBlock, TextItemBlock
 from ..types import AgentMetadata, Currency, SourceType
 from ..utils import TTLCache
+from .v1alpha2.agent import Agent
 
 
 class RequestSenderBase(abc.ABC):

--- a/theoriq/api/v1alpha2/agent.py
+++ b/theoriq/api/v1alpha2/agent.py
@@ -10,7 +10,7 @@ from jsonschema import SchemaError, ValidationError
 from jsonschema.validators import Draft7Validator
 from pydantic import BaseModel
 
-from .biscuit import (
+from theoriq.biscuit import (
     AgentAddress,
     AuthorizationError,
     RequestBiscuit,
@@ -19,9 +19,9 @@ from .biscuit import (
     TheoriqCost,
     VerificationError,
 )
-from .biscuit.authentication_biscuit import AuthenticationBiscuit, AuthenticationFacts
-from .biscuit.payload_hash import PayloadHash
-from .biscuit.theoriq_biscuit import TheoriqBiscuit, TheoriqFactBase
+from theoriq.biscuit.authentication_biscuit import AuthenticationBiscuit, AuthenticationFacts
+from theoriq.biscuit.payload_hash import PayloadHash
+from theoriq.biscuit.theoriq_biscuit import TheoriqBiscuit, TheoriqFactBase
 
 
 # as from .api.v1alpha2.schemas import AgentSchemas leads to circular import

--- a/theoriq/api/v1alpha2/agent.py
+++ b/theoriq/api/v1alpha2/agent.py
@@ -12,16 +12,18 @@ from pydantic import BaseModel
 
 from theoriq.biscuit import (
     AgentAddress,
+    AuthenticationBiscuit,
+    AuthenticationFacts,
     AuthorizationError,
+    PayloadHash,
     RequestBiscuit,
     RequestFacts,
     ResponseBiscuit,
+    TheoriqBiscuit,
     TheoriqCost,
+    TheoriqFactBase,
     VerificationError,
 )
-from theoriq.biscuit.authentication_biscuit import AuthenticationBiscuit, AuthenticationFacts
-from theoriq.biscuit.payload_hash import PayloadHash
-from theoriq.biscuit.theoriq_biscuit import TheoriqBiscuit, TheoriqFactBase
 
 
 # as from .api.v1alpha2.schemas import AgentSchemas leads to circular import

--- a/theoriq/api/v1alpha2/configure.py
+++ b/theoriq/api/v1alpha2/configure.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable
 
-from theoriq import Agent
 from theoriq.biscuit import AgentAddress, RequestFact, TheoriqBiscuit
 
+from .agent import Agent
 from .protocol import ProtocolClient
 
 logger = logging.getLogger(__name__)

--- a/theoriq/api/v1alpha2/execute.py
+++ b/theoriq/api/v1alpha2/execute.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
-from theoriq.agent import Agent
 from theoriq.biscuit import AgentAddress, RequestBiscuit, ResponseBiscuit, TheoriqBiscuit, TheoriqBudget
 from theoriq.biscuit.facts import TheoriqRequest
 from theoriq.dialog import Dialog, DialogItem, ItemBlock
 from theoriq.types import AgentMetadata, Metric
 
 from ..common import ExecuteContextBase, ExecuteResponse
+from .agent import Agent
 from .protocol.protocol_client import ProtocolClient, RequestStatus
 from .schemas.request import Configuration, ExecuteRequestBody
 

--- a/theoriq/api/v1alpha2/protocol/protocol_client.py
+++ b/theoriq/api/v1alpha2/protocol/protocol_client.py
@@ -10,12 +10,12 @@ import httpx
 from biscuit_auth import PublicKey
 from pydantic import BaseModel
 
-from theoriq import Agent
 from theoriq.biscuit import AgentAddress, PayloadHash, RequestBiscuit, RequestFact, ResponseFact, TheoriqBiscuit
 from theoriq.biscuit.authentication_biscuit import AuthenticationBiscuit
 from theoriq.types import Metric
 from theoriq.utils import TTLCache, is_protocol_secured
 
+from ..agent import Agent
 from ..schemas.agent import AgentResponse
 from ..schemas.api import PublicKeyResponse
 from ..schemas.biscuit import BiscuitResponse

--- a/theoriq/api/v1alpha2/publish.py
+++ b/theoriq/api/v1alpha2/publish.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import threading
 from typing import Callable, Optional
 
-from theoriq import Agent
-from theoriq.api.v1alpha2 import ProtocolClient
-from theoriq.api.v1alpha2.protocol.biscuit_provider import BiscuitProviderFromPrivateKey
+from .agent import Agent
+from .protocol import ProtocolClient
+from .protocol.biscuit_provider import BiscuitProviderFromPrivateKey
 
 
 class PublisherContext:

--- a/theoriq/biscuit/__init__.py
+++ b/theoriq/biscuit/__init__.py
@@ -1,8 +1,24 @@
 from .agent_address import AgentAddress
+from .authentication_biscuit import AuthenticationBiscuit, AuthenticationFacts
+from .error import AuthorizationError, ParseBiscuitError, TheoriqBiscuitError, VerificationError
+from .facts import (
+    BudgetFact,
+    CostFact,
+    ExecuteRequestFacts,
+    ExecuteResponseFacts,
+    ExpiresAtFact,
+    FactConvertibleBase,
+    RequestFact,
+    ResponseFact,
+    SubjectFact,
+    TheoriqBudget,
+    TheoriqCost,
+    TheoriqFactBase,
+    TheoriqRequest,
+    TheoriqResponse,
+)
 from .payload_hash import PayloadHash
-from .facts import RequestFact, ResponseFact, TheoriqCost, TheoriqBudget, TheoriqResponse, TheoriqRequest
-from .error import TheoriqBiscuitError, AuthorizationError, ParseBiscuitError, VerificationError
-from .theoriq_biscuit import TheoriqBiscuit
-from .response_biscuit import ResponseBiscuit, ResponseFacts
 from .request_biscuit import RequestBiscuit, RequestFacts
+from .response_biscuit import ResponseBiscuit, ResponseFacts
+from .theoriq_biscuit import TheoriqBiscuit
 from .utils import get_new_key_pair

--- a/theoriq/biscuit/request_biscuit.py
+++ b/theoriq/biscuit/request_biscuit.py
@@ -8,9 +8,10 @@ from uuid import UUID
 from biscuit_auth import Biscuit, BlockBuilder, KeyPair  # pylint: disable=E0611
 from biscuit_auth.biscuit_auth import PrivateKey, PublicKey  # type: ignore
 
-from . import AgentAddress, TheoriqBiscuit
+from .agent_address import AgentAddress
 from .facts import ExecuteRequestFacts, TheoriqBudget, TheoriqCost, TheoriqRequest, TheoriqResponse
 from .response_biscuit import ResponseBiscuit, ResponseFacts
+from .theoriq_biscuit import TheoriqBiscuit
 from .utils import from_base64_token
 
 

--- a/theoriq/biscuit/response_biscuit.py
+++ b/theoriq/biscuit/response_biscuit.py
@@ -4,8 +4,8 @@ from uuid import UUID
 
 from biscuit_auth import Biscuit, BlockBuilder  # pylint: disable=E0611
 
-from theoriq.biscuit import TheoriqBiscuit, TheoriqCost, TheoriqResponse
-from theoriq.biscuit.facts import ExecuteResponseFacts
+from .facts import ExecuteResponseFacts, TheoriqCost, TheoriqResponse
+from .theoriq_biscuit import TheoriqBiscuit
 
 
 class ResponseBiscuit:

--- a/theoriq/extra/flask/v1alpha2/flask.py
+++ b/theoriq/extra/flask/v1alpha2/flask.py
@@ -43,11 +43,11 @@ def theoriq_blueprint(
     """
 
     main_blueprint = Blueprint("main_blueprint", __name__)
-    Agent.validate_schemas(schemas.configuration, schemas.notification, schemas.execute)  # type: ignore
+    Agent.validate_schemas(schemas)
 
     @main_blueprint.before_request
     def set_context() -> None:
-        agent_var.set(Agent(agent_config, schemas.configuration, schemas.notification, schemas.execute))  # type: ignore
+        agent_var.set(Agent(agent_config, schemas))
 
     configure_error_handlers(main_blueprint)
 
@@ -187,23 +187,12 @@ def _execute_async(
 
 def get_configuration_schema() -> Response:
     agent = agent_var.get()
-    return jsonify(agent.configuration_schema or {})
+    return jsonify(agent.schemas.configuration or {})
 
 
 def get_schemas() -> Response:
     agent = agent_var.get()
-
-    execute_schemas = (
-        None
-        if agent.execute_schemas is None
-        else {key: value.model_dump() for key, value in agent.execute_schemas.items()}
-    )
-    schemas = {
-        "configuration": agent.configuration_schema,
-        "notification": agent.notification_schema,
-        "execute": execute_schemas,
-    }
-    return jsonify(schemas)
+    return jsonify(agent.schemas.model_dump())
 
 
 def validate_configuration(agent_id: str) -> Response:

--- a/theoriq/extra/flask/v1alpha2/flask.py
+++ b/theoriq/extra/flask/v1alpha2/flask.py
@@ -9,9 +9,9 @@ from flask import Blueprint, Response, jsonify, request
 
 import theoriq
 from theoriq import ExecuteRuntimeError
-from theoriq.agent import Agent, AgentDeploymentConfiguration
 from theoriq.api import ExecuteContextV1alpha2, ExecuteRequestFnV1alpha2
 from theoriq.api.v1alpha2 import ConfigureContext
+from theoriq.api.v1alpha2.agent import Agent, AgentDeploymentConfiguration
 from theoriq.api.v1alpha2.configure import AgentConfigurator
 from theoriq.api.v1alpha2.schemas import AgentSchemas, ExecuteRequestBody
 from theoriq.biscuit import TheoriqBiscuit, TheoriqBiscuitError, TheoriqCost

--- a/theoriq/extra/globals.py
+++ b/theoriq/extra/globals.py
@@ -1,6 +1,6 @@
 from contextvars import ContextVar
 
-from theoriq.api.v1alpha2.agent import Agent
+from theoriq import Agent
 
 # Global variable used to access the current agent context
 agent_var: ContextVar[Agent] = ContextVar("agent")

--- a/theoriq/extra/globals.py
+++ b/theoriq/extra/globals.py
@@ -1,6 +1,6 @@
 from contextvars import ContextVar
 
-from theoriq.agent import Agent
+from theoriq.api.v1alpha2.agent import Agent
 
 # Global variable used to access the current agent context
 agent_var: ContextVar[Agent] = ContextVar("agent")


### PR DESCRIPTION
Move `Agent` and `AgentDeploymentConfiguration` from `theoriq/agent.py` to `theoriq/api/v1alpha2/agent.py`
This fixes some boilerplate code introduced in #111 