### PR TITLE
Feature update ProtocolClient

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -58,3 +58,15 @@ def user_manager() -> DeployedAgentManager:
 @pytest.fixture()
 def user_messenger() -> Messenger:
     return Messenger.from_api_key(api_key=os.environ["THEORIQ_API_KEY"])
+
+
+@pytest.fixture()
+def owner_manager(agent_registry: AgentRegistry) -> DeployedAgentManager:
+    owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
+    return DeployedAgentManager.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])
+
+
+@pytest.fixture()
+def owner_messenger(agent_registry: AgentRegistry) -> Messenger:
+    owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
+    return Messenger.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])

--- a/tests/integration/test_as_agent.py
+++ b/tests/integration/test_as_agent.py
@@ -16,18 +16,6 @@ def is_owned_by_agent(agent: AgentResponse) -> bool:
     return source_type.is_agent
 
 
-@pytest.fixture()
-def owner_manager(agent_registry: AgentRegistry) -> DeployedAgentManager:
-    owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
-    return DeployedAgentManager.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])
-
-
-@pytest.fixture()
-def owner_messenger(agent_registry: AgentRegistry) -> Messenger:
-    owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
-    return Messenger.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])
-
-
 @pytest.mark.order(1)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_registration_owner(

--- a/tests/integration/test_as_user.py
+++ b/tests/integration/test_as_user.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from datetime import datetime, timedelta, timezone
 from typing import Dict
 
 import pytest
@@ -100,6 +101,16 @@ def test_system_tag(agent_registry: AgentRegistry, user_manager: DeployedAgentMa
 
     agent = user_manager.get_agent(agent_id=str(config.address))
     assert "curated" not in agent.system.tags
+
+
+@pytest.mark.order(8)
+@pytest.mark.usefixtures("agent_flask_apps")
+def test_create_api_key(user_manager: DeployedAgentManager) -> None:
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(minutes=1)
+    response = user_manager.create_api_key(expires_at)
+
+    assert isinstance(response["biscuit"], str)
+    assert response["data"]["expiresAt"] == int(expires_at.timestamp())
 
 
 @pytest.mark.order(-1)

--- a/tests/integration/test_as_user.py
+++ b/tests/integration/test_as_user.py
@@ -84,6 +84,22 @@ def test_updating(agent_registry: AgentRegistry, user_manager: DeployedAgentMana
 
     assert response.metadata.name == "Updated Owner Agent"
 
+@pytest.mark.order(7)
+@pytest.mark.usefixtures("agent_flask_apps")
+def test_system_tag(agent_registry: AgentRegistry, user_manager: DeployedAgentManager) -> None:
+    owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
+    config = AgentDeploymentConfiguration.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])
+
+    user_manager.add_system_tag(agent_id=str(config.address), tag="curated")
+
+    agent = user_manager.get_agent(agent_id=str(config.address))
+    assert "curated" in agent.system.tags
+
+    user_manager.delete_system_tag(agent_id=str(config.address), tag="curated")
+
+    agent = user_manager.get_agent(agent_id=str(config.address))
+    assert "curated" not in agent.system.tags
+
 
 @pytest.mark.order(-1)
 @pytest.mark.usefixtures("agent_flask_apps")

--- a/tests/integration/test_as_user.py
+++ b/tests/integration/test_as_user.py
@@ -84,6 +84,7 @@ def test_updating(agent_registry: AgentRegistry, user_manager: DeployedAgentMana
 
     assert response.metadata.name == "Updated Owner Agent"
 
+
 @pytest.mark.order(7)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_system_tag(agent_registry: AgentRegistry, user_manager: DeployedAgentManager) -> None:

--- a/tests/integration/test_protocol_client_v1alpha2.py
+++ b/tests/integration/test_protocol_client_v1alpha2.py
@@ -1,30 +1,7 @@
-from datetime import datetime, timedelta, timezone
-
-import pytest
-
 from theoriq.api.v1alpha2 import ProtocolClient
-from theoriq.api.v1alpha2.protocol.biscuit_provider import BiscuitProviderFromAPIKey
-from theoriq.utils import must_read_env_str
 
 
-@pytest.fixture
-def client() -> ProtocolClient:
-    return ProtocolClient("http://localhost:8080")
-
-
-@pytest.fixture
-def biscuit_provider(client: ProtocolClient) -> BiscuitProviderFromAPIKey:
-    return BiscuitProviderFromAPIKey(must_read_env_str("THEORIQ_API_KEY"), client=client)
-
-
-def test_get_public_key(client: ProtocolClient) -> None:
-    pub_key = client.get_public_key()
+def test_get_public_key():
+    pc = ProtocolClient("http://localhost:8080")
+    pub_key = pc.get_public_key()
     assert pub_key.key_type == "ed25519"
-
-
-def test_create_api_key(client: ProtocolClient, biscuit_provider: BiscuitProviderFromAPIKey) -> None:
-    expires_at = datetime.now(tz=timezone.utc) + timedelta(minutes=1)
-    response = client.create_api_key(biscuit_provider.get_biscuit(), expires_at)
-
-    assert isinstance(response["biscuit"], str)
-    assert response["data"]["expiresAt"] == int(expires_at.timestamp())

--- a/tests/integration/test_protocol_client_v1alpha2.py
+++ b/tests/integration/test_protocol_client_v1alpha2.py
@@ -10,6 +10,7 @@ def test_get_public_key():
     pub_key = client.get_public_key()
     assert pub_key.key_type == "ed25519"
 
+
 def test_create_api_key():
     client = ProtocolClient("http://localhost:8080")
 
@@ -19,4 +20,3 @@ def test_create_api_key():
 
     assert isinstance(response["biscuit"], str)
     assert response["data"]["expiresAt"] == int(expires_at.timestamp())
-

--- a/tests/integration/test_protocol_client_v1alpha2.py
+++ b/tests/integration/test_protocol_client_v1alpha2.py
@@ -1,20 +1,28 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from theoriq.api.v1alpha2 import ProtocolClient
 from theoriq.api.v1alpha2.protocol.biscuit_provider import BiscuitProviderFromAPIKey
 from theoriq.utils import must_read_env_str
 
 
-def test_get_public_key():
-    client = ProtocolClient("http://localhost:8080")
+@pytest.fixture
+def client() -> ProtocolClient:
+    return ProtocolClient("http://localhost:8080")
+
+
+@pytest.fixture
+def biscuit_provider(client: ProtocolClient) -> BiscuitProviderFromAPIKey:
+    return BiscuitProviderFromAPIKey(must_read_env_str("THEORIQ_API_KEY"), client=client)
+
+
+def test_get_public_key(client: ProtocolClient) -> None:
     pub_key = client.get_public_key()
     assert pub_key.key_type == "ed25519"
 
 
-def test_create_api_key():
-    client = ProtocolClient("http://localhost:8080")
-
-    biscuit_provider = BiscuitProviderFromAPIKey(must_read_env_str("THEORIQ_API_KEY"), client=client)
+def test_create_api_key(client: ProtocolClient, biscuit_provider: BiscuitProviderFromAPIKey) -> None:
     expires_at = datetime.now(tz=timezone.utc) + timedelta(minutes=1)
     response = client.create_api_key(biscuit_provider.get_biscuit(), expires_at)
 

--- a/tests/integration/test_protocol_client_v1alpha2.py
+++ b/tests/integration/test_protocol_client_v1alpha2.py
@@ -1,7 +1,22 @@
+from datetime import datetime, timezone, timedelta
+
 from theoriq.api.v1alpha2 import ProtocolClient
+from theoriq.api.v1alpha2.protocol.biscuit_provider import BiscuitProviderFromAPIKey
+from theoriq.utils import must_read_env_str
 
 
 def test_get_public_key():
-    pc = ProtocolClient("http://localhost:8080")
-    pub_key = pc.get_public_key()
+    client = ProtocolClient("http://localhost:8080")
+    pub_key = client.get_public_key()
     assert pub_key.key_type == "ed25519"
+
+def test_create_api_key():
+    client = ProtocolClient("http://localhost:8080")
+
+    biscuit_provider = BiscuitProviderFromAPIKey(must_read_env_str("THEORIQ_API_KEY"), client=client)
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(minutes=1)
+    response = client.create_api_key(biscuit_provider.get_biscuit(), expires_at)
+
+    assert isinstance(response["biscuit"], str)
+    assert response["data"]["expiresAt"] == int(expires_at.timestamp())
+

--- a/tests/integration/test_web3.py
+++ b/tests/integration/test_web3.py
@@ -26,7 +26,6 @@ def test_registration_owner(
 @pytest.mark.order(2)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_post_web3_transaction_as_user(user_manager: DeployedAgentManager) -> None:
-
     with pytest.raises(httpx.HTTPStatusError) as e:
         user_manager.post_web3_transaction(ETH_SEPOLIA_TX_HASH, ETH_SEPOLIA_CHAIN_ID)
     assert e.value.response.status_code == 401
@@ -42,6 +41,7 @@ def test_post_web3_transaction(owner_manager: DeployedAgentManager) -> None:
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_get_web3_transaction(owner_manager: DeployedAgentManager) -> None:
     tx = owner_manager.get_web3_transaction(ETH_SEPOLIA_TX_HASH)
+
     assert isinstance(tx, AgentWeb3Transaction)
     assert tx.chain_id == ETH_SEPOLIA_CHAIN_ID
     assert tx.hash == ETH_SEPOLIA_TX_HASH
@@ -52,6 +52,7 @@ def test_get_web3_transaction(owner_manager: DeployedAgentManager) -> None:
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_get_web3_transactions_as_user(user_manager: DeployedAgentManager) -> None:
     transactions = user_manager.get_web3_transactions()
+
     assert len(transactions) >= 1
     assert isinstance(transactions[0], AgentWeb3Transaction)
 
@@ -60,6 +61,7 @@ def test_get_web3_transactions_as_user(user_manager: DeployedAgentManager) -> No
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_get_web3_transactions(owner_manager: DeployedAgentManager) -> None:
     transactions = owner_manager.get_web3_transactions()
+
     assert len(transactions) >= 1
     assert isinstance(transactions[0], AgentWeb3Transaction)
 
@@ -67,5 +69,5 @@ def test_get_web3_transactions(owner_manager: DeployedAgentManager) -> None:
 @pytest.mark.order(-1)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_deletion_owner(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager) -> None:
-    for agent in agent_map.values():  # should be the only one in the map
+    for agent in agent_map.values():
         user_manager.delete_agent(agent.system.id)

--- a/tests/integration/test_web3.py
+++ b/tests/integration/test_web3.py
@@ -1,0 +1,61 @@
+from typing import Dict
+
+import pytest
+from tests.integration.agent_registry import AgentRegistry, AgentType
+
+from theoriq.api.v1alpha2 import AgentResponse
+from theoriq.api.v1alpha2.manage import DeployedAgentManager
+from theoriq.api.v1alpha2.schemas import AgentWeb3Transaction, AgentWeb3TransactionHash
+
+
+@pytest.mark.order(1)
+@pytest.mark.usefixtures("agent_flask_apps")
+def test_registration_owner(
+    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager
+) -> None:
+    owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
+    agent = user_manager.create_agent(owner_agent_data.spec.metadata, owner_agent_data.spec.configuration)
+    agent_map[agent.system.id] = agent
+
+
+@pytest.mark.order(2)
+@pytest.mark.usefixtures("agent_flask_apps")
+def test_post_web3_transaction_as_user(user_manager: DeployedAgentManager) -> None:
+    with pytest.raises(ValueError, match="Only agent can submit a transaction; authorized as user"):
+        user_manager.submit_web3_transaction(raw_transaction="0x0123456789abcdef", metadata={"abc": "xyz"})
+
+
+@pytest.mark.order(3)
+@pytest.mark.usefixtures("agent_flask_apps")
+def test_post_web3_transaction(owner_manager: DeployedAgentManager) -> None:
+    tx_hash = owner_manager.submit_web3_transaction(raw_transaction="0x0123456789abcdef", metadata={"abc": "xyz"})
+
+    assert isinstance(tx_hash, AgentWeb3TransactionHash)
+    assert isinstance(tx_hash.tx_hash, str)
+
+    transaction = owner_manager.get_web3_transaction(tx_hash.tx_hash)
+
+    assert isinstance(transaction, AgentWeb3Transaction)
+
+
+@pytest.mark.order(4)
+@pytest.mark.usefixtures("agent_flask_apps")
+def test_get_web3_transactions_as_user(user_manager: DeployedAgentManager) -> None:
+    transactions = user_manager.get_web3_transactions()
+    assert len(transactions) > 1
+    assert isinstance(transactions[0], AgentWeb3Transaction)
+
+
+@pytest.mark.order(5)
+@pytest.mark.usefixtures("agent_flask_apps")
+def test_get_web3_transactions(owner_manager: DeployedAgentManager) -> None:
+    transactions = owner_manager.get_web3_transactions()
+    assert len(transactions) == 1
+    assert isinstance(transactions[0], AgentWeb3Transaction)
+
+
+@pytest.mark.order(-1)
+@pytest.mark.usefixtures("agent_flask_apps")
+def test_deletion_owner(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager) -> None:
+    for agent in agent_map.values():  # should be the only one in the map
+        user_manager.delete_agent(agent.system.id)

--- a/theoriq/api/v1alpha2/manage.py
+++ b/theoriq/api/v1alpha2/manage.py
@@ -72,6 +72,12 @@ class AgentManagerBase(abc.ABC):
     def delete_agent(self, agent_id: str) -> None:
         self._client.delete_agent(biscuit=self._biscuit_provider.get_biscuit(), agent_id=agent_id)
 
+    def add_system_tag(self, *, agent_id: str, tag: str) -> None:
+        self._client.post_system_tag(biscuit=self._biscuit_provider.get_biscuit(), agent_id=agent_id, tag=tag)
+
+    def delete_system_tag(self, *, agent_id: str, tag: str) -> None:
+        self._client.delete_system_tag(biscuit=self._biscuit_provider.get_biscuit(), agent_id=agent_id, tag=tag)
+
     @classmethod
     def from_api_key(cls, api_key: str) -> Self:
         return cls(biscuit_provider=BiscuitProviderFactory.from_api_key(api_key=api_key))

--- a/theoriq/api/v1alpha2/manage.py
+++ b/theoriq/api/v1alpha2/manage.py
@@ -23,7 +23,6 @@ class AgentManagerBase(abc.ABC):
         self._biscuit_provider = biscuit_provider
 
     def create_api_key(self, expires_at: datetime) -> Dict[str, Any]:
-        # only works as user
         return self._client.create_api_key(self._biscuit_provider.get_biscuit(), expires_at)
 
     def get_agents(self) -> List[AgentResponse]:

--- a/theoriq/api/v1alpha2/protocol/protocol_client.py
+++ b/theoriq/api/v1alpha2/protocol/protocol_client.py
@@ -73,6 +73,17 @@ class ProtocolClient:
             response.raise_for_status()
             return BiscuitResponse.model_validate(response.json())
 
+    def create_api_key(self, biscuit: TheoriqBiscuit, expires_at: datetime) -> Dict[str, Any]:
+        url = f"{self._uri}/auth/api-keys"
+        headers = biscuit.to_headers()
+
+        expiration_timestamp = int(expires_at.timestamp())
+        body = {"expiresAt": expiration_timestamp}
+        with httpx.Client(timeout=self._timeout) as client:
+            response = client.post(url=url, json=body, headers=headers)
+            response.raise_for_status()
+            return response.json()
+
     def get_agent(self, agent_id: str, biscuit: Optional[TheoriqBiscuit] = None) -> AgentResponse:
         headers = biscuit.to_headers() if biscuit is not None else None
         with httpx.Client(timeout=self._timeout) as client:

--- a/theoriq/api/v1alpha2/protocol/protocol_client.py
+++ b/theoriq/api/v1alpha2/protocol/protocol_client.py
@@ -146,9 +146,10 @@ class ProtocolClient:
         if cached_response:
             return cached_response
 
+        url = f"{self._uri}/agents/{agent_address.address}/configuration"
         headers = request_biscuit.to_headers()
         with httpx.Client(timeout=self._timeout) as client:
-            response = client.get(url=f"{self._uri}/agents/{agent_address.address}/configuration", headers=headers)
+            response = client.get(url=url, headers=headers)
             response.raise_for_status()
             configuration = response.json()
             if configuration is not None:
@@ -172,6 +173,28 @@ class ProtocolClient:
             response = client.post(url=url, headers=headers)
             response.raise_for_status()
             return AgentResponse.model_validate(response.json())
+
+    def delete_configure(self, biscuit: TheoriqBiscuit, to_addr: str) -> AgentResponse:
+        url = f'{self._uri}/agents/{to_addr.removeprefix("0x")}/configure'
+        headers = biscuit.to_headers()
+        with httpx.Client(timeout=self._timeout) as client:
+            response = client.delete(url=url, headers=headers)
+            response.raise_for_status()
+            return AgentResponse.model_validate(response.json())
+
+    def post_system_tag(self, biscuit: TheoriqBiscuit, *, agent_id: str, tag: str) -> None:
+        url = f"{self._uri}/agents/0x{agent_id.removeprefix('0x')}/system-tags/{tag}"
+        headers = biscuit.to_headers()
+        with httpx.Client(timeout=self._timeout) as client:
+            response = client.post(url=url, headers=headers)
+            response.raise_for_status()
+
+    def delete_system_tag(self, biscuit: TheoriqBiscuit, *, agent_id: str, tag: str) -> None:
+        url = f"{self._uri}/agents/0x{agent_id.removeprefix('0x')}/system-tags/{tag}"
+        headers = biscuit.to_headers()
+        with httpx.Client(timeout=self._timeout) as client:
+            response = client.delete(url=url, headers=headers)
+            response.raise_for_status()
 
     def post_request_success(self, theoriq_biscuit: TheoriqBiscuit, response: Optional[str], agent: Agent) -> None:
         self._post_request_complete(theoriq_biscuit, response, agent, RequestStatus.SUCCESS)

--- a/theoriq/api/v1alpha2/protocol/protocol_client.py
+++ b/theoriq/api/v1alpha2/protocol/protocol_client.py
@@ -19,7 +19,6 @@ from ..agent import Agent
 from ..schemas import (
     AgentResponse,
     AgentWeb3Transaction,
-    AgentWeb3TransactionHash,
     BiscuitResponse,
     EventRequestBody,
     MetricsRequestBody,
@@ -322,21 +321,6 @@ class ProtocolClient:
             response.raise_for_status()
             return [AgentWeb3Transaction.model_validate(item) for item in response.json()]
 
-    def post_web3_transaction(
-        self, biscuit: TheoriqBiscuit, raw_transaction: str, metadata: Optional[Dict[str, str]] = None
-    ) -> AgentWeb3TransactionHash:
-        url = f"{self._uri}/web3/transactions"
-        headers = biscuit.to_headers()
-
-        body: Dict[str, Any] = {"rawTransaction": raw_transaction}
-        if metadata is not None:
-            body["metadata"] = metadata
-
-        with httpx.Client(timeout=self._timeout) as client:
-            response = client.post(url=url, json=body, headers=headers)
-            response.raise_for_status()
-            return AgentWeb3TransactionHash.model_validate(response.json())
-
     def get_web3_transaction(self, biscuit: TheoriqBiscuit, tx_hash: str) -> AgentWeb3Transaction:
         url = f"{self._uri}/web3/transactions/{tx_hash}"
         headers = biscuit.to_headers()
@@ -345,7 +329,7 @@ class ProtocolClient:
             response.raise_for_status()
             return AgentWeb3Transaction.model_validate(response.json())
 
-    def store_web3_transaction(
+    def post_web3_transaction_by_hash(
         self, biscuit: TheoriqBiscuit, tx_hash: str, chain_id: int, metadata: Optional[Dict[str, str]] = None
     ) -> None:
         url = f"{self._uri}/web3/transactions/{tx_hash}"

--- a/theoriq/api/v1alpha2/schemas/__init__.py
+++ b/theoriq/api/v1alpha2/schemas/__init__.py
@@ -1,5 +1,9 @@
 from .agent import AgentResponse
+from .api import PublicKeyResponse
+from .biscuit import BiscuitResponse, BiscuitResponseData
 from .challenge import ChallengeRequestBody, ChallengeResponseBody
-from .request import ExecuteRequestBody
+from .event_request import EventRequestBody
 from .metrics import MetricsRequestBody
+from .request import ExecuteRequestBody
 from .schemas import AgentSchemas, ExecuteSchema
+from .web3 import AgentWeb3Transaction, AgentWeb3TransactionHash

--- a/theoriq/api/v1alpha2/schemas/__init__.py
+++ b/theoriq/api/v1alpha2/schemas/__init__.py
@@ -6,4 +6,4 @@ from .event_request import EventRequestBody
 from .metrics import MetricsRequestBody
 from .request import ExecuteRequestBody
 from .schemas import AgentSchemas, ExecuteSchema
-from .web3 import AgentWeb3Transaction, AgentWeb3TransactionHash
+from .web3 import AgentWeb3Transaction

--- a/theoriq/api/v1alpha2/schemas/web3.py
+++ b/theoriq/api/v1alpha2/schemas/web3.py
@@ -10,7 +10,3 @@ class AgentWeb3Transaction(BaseModel):
     metadata: Optional[Dict[str, str]] = None
     signer: str
     submitted_at: str = Field(..., alias="submittedAt")
-
-
-class AgentWeb3TransactionHash(BaseModel):
-    tx_hash: str = Field(..., alias="txHash")

--- a/theoriq/api/v1alpha2/schemas/web3.py
+++ b/theoriq/api/v1alpha2/schemas/web3.py
@@ -1,12 +1,15 @@
 from typing import Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 
 class AgentWeb3Transaction(BaseModel):
-    agent_id: str = Field(..., alias="agentId")
-    chain_id: int = Field(..., alias="chainId")
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    agent_id: str
+    chain_id: int
     hash: str
     metadata: Optional[Dict[str, str]] = None
     signer: str
-    submitted_at: str = Field(..., alias="submittedAt")
+    submitted_at: str

--- a/theoriq/api/v1alpha2/schemas/web3.py
+++ b/theoriq/api/v1alpha2/schemas/web3.py
@@ -1,0 +1,16 @@
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AgentWeb3Transaction(BaseModel):
+    agent_id: str = Field(..., alias="agentId")
+    chain_id: int = Field(..., alias="chainId")
+    hash: str
+    metadata: Optional[Dict[str, str]] = None
+    signer: str
+    submitted_at: str = Field(..., alias="submittedAt")
+
+
+class AgentWeb3TransactionHash(BaseModel):
+    tx_hash: str = Field(..., alias="txHash")


### PR DESCRIPTION
Add following functionality to both `ProtocolClient` and `AgentManager`:
- Create API key
- Add/remove system tag
- Get web3 transactions
- Post web3 transaction by hash
