### PR TITLE
Feature AgentManager

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -61,9 +61,9 @@ def user_messenger() -> Messenger:
 
 
 @pytest.fixture()
-def owner_manager(agent_registry: AgentRegistry) -> DeployedAgentManager:
+def owner_manager(agent_registry: AgentRegistry) -> AgentManager:
     owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
-    return DeployedAgentManager.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])
+    return AgentManager.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])
 
 
 @pytest.fixture()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,7 +8,7 @@ from tests.integration.agent_registry import AgentRegistry, AgentType
 from tests.integration.agent_runner import AgentRunner, TestConfig
 
 from theoriq.api.v1alpha2 import AgentResponse
-from theoriq.api.v1alpha2.manage import DeployedAgentManager
+from theoriq.api.v1alpha2.manage import AgentManager
 from theoriq.api.v1alpha2.message import Messenger
 
 dotenv.load_dotenv()
@@ -51,8 +51,8 @@ def agent_map() -> Generator[Dict[str, AgentResponse], None, None]:
 
 
 @pytest.fixture()
-def user_manager() -> DeployedAgentManager:
-    return DeployedAgentManager.from_api_key(api_key=os.environ["THEORIQ_API_KEY"])
+def user_manager() -> AgentManager:
+    return AgentManager.from_api_key(api_key=os.environ["THEORIQ_API_KEY"])
 
 
 @pytest.fixture()

--- a/tests/integration/test_as_agent.py
+++ b/tests/integration/test_as_agent.py
@@ -5,7 +5,7 @@ from tests.integration.agent_registry import AgentRegistry, AgentType
 from tests.integration.agent_runner import AgentRunner
 
 from theoriq.api.v1alpha2 import AgentResponse
-from theoriq.api.v1alpha2.manage import DeployedAgentManager
+from theoriq.api.v1alpha2.manage import AgentManager
 from theoriq.api.v1alpha2.message import Messenger
 from theoriq.dialog import TextItemBlock
 from theoriq.types import SourceType
@@ -17,9 +17,9 @@ def is_owned_by_agent(agent: AgentResponse) -> bool:
 
 
 @pytest.fixture()
-def owner_manager(agent_registry: AgentRegistry) -> DeployedAgentManager:
+def owner_manager(agent_registry: AgentRegistry) -> AgentManager:
     owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
-    return DeployedAgentManager.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])
+    return AgentManager.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])
 
 
 @pytest.fixture()
@@ -31,7 +31,7 @@ def owner_messenger(agent_registry: AgentRegistry) -> Messenger:
 @pytest.mark.order(1)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_registration_owner(
-    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager
+    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: AgentManager
 ) -> None:
     owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
     agent = user_manager.create_agent(owner_agent_data.spec.metadata, owner_agent_data.spec.configuration)
@@ -41,7 +41,7 @@ def test_registration_owner(
 @pytest.mark.order(2)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_registration_basic(
-    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], owner_manager: DeployedAgentManager
+    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], owner_manager: AgentManager
 ) -> None:
     for basic_agent_data in agent_registry.get_agents_of_type(AgentType.BASIC):
         agent = owner_manager.create_agent(basic_agent_data.spec.metadata, basic_agent_data.spec.configuration)
@@ -65,7 +65,7 @@ def test_messenger(agent_map: Dict[str, AgentResponse], owner_messenger: Messeng
 
 @pytest.mark.order(-2)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_deletion_basic(agent_map: Dict[str, AgentResponse], owner_manager: DeployedAgentManager) -> None:
+def test_deletion_basic(agent_map: Dict[str, AgentResponse], owner_manager: AgentManager) -> None:
     basic_agents = [agent for agent in agent_map.values() if is_owned_by_agent(agent)]
     for basic_agent in basic_agents:
         owner_manager.delete_agent(basic_agent.system.id)
@@ -76,6 +76,6 @@ def test_deletion_basic(agent_map: Dict[str, AgentResponse], owner_manager: Depl
 
 @pytest.mark.order(-1)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_deletion_owner(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager) -> None:
+def test_deletion_owner(agent_map: Dict[str, AgentResponse], user_manager: AgentManager) -> None:
     for agent in agent_map.values():  # should be the only one in the map
         user_manager.delete_agent(agent.system.id)

--- a/tests/integration/test_as_agent.py
+++ b/tests/integration/test_as_agent.py
@@ -34,7 +34,7 @@ def test_registration_owner(
     agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: AgentManager
 ) -> None:
     owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
-    agent = user_manager.create_agent(owner_agent_data.spec.metadata, owner_agent_data.spec.configuration)
+    agent = user_manager.create_agent_from_data(owner_agent_data)
     agent_map[agent.system.id] = agent
 
 
@@ -44,7 +44,7 @@ def test_registration_basic(
     agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], owner_manager: AgentManager
 ) -> None:
     for basic_agent_data in agent_registry.get_agents_of_type(AgentType.BASIC):
-        agent = owner_manager.create_agent(basic_agent_data.spec.metadata, basic_agent_data.spec.configuration)
+        agent = owner_manager.create_agent_from_data(basic_agent_data)
         agent_map[agent.system.id] = agent
 
 

--- a/tests/integration/test_as_user.py
+++ b/tests/integration/test_as_user.py
@@ -8,7 +8,7 @@ from tests.integration.utils import agents_are_equal
 
 from theoriq import AgentDeploymentConfiguration
 from theoriq.api.v1alpha2 import AgentResponse
-from theoriq.api.v1alpha2.manage import DeployedAgentManager
+from theoriq.api.v1alpha2.manage import AgentManager
 from theoriq.api.v1alpha2.message import Messenger
 from theoriq.dialog import TextItemBlock
 
@@ -16,7 +16,7 @@ from theoriq.dialog import TextItemBlock
 @pytest.mark.order(1)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_registration(
-    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager
+    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: AgentManager
 ) -> None:
     agent_data_objs = agent_registry.get_agents_of_types([AgentType.OWNER, AgentType.BASIC])
     for agent_data in agent_data_objs:
@@ -26,7 +26,7 @@ def test_registration(
 
 @pytest.mark.order(2)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_minting(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager) -> None:
+def test_minting(agent_map: Dict[str, AgentResponse], user_manager: AgentManager) -> None:
     for agent_id in agent_map.keys():
         agent = user_manager.mint_agent(agent_id)
         assert agent.system.state == "online"
@@ -34,7 +34,7 @@ def test_minting(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgen
 
 @pytest.mark.order(3)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_get_agents(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager) -> None:
+def test_get_agents(agent_map: Dict[str, AgentResponse], user_manager: AgentManager) -> None:
     agents = user_manager.get_agents()
     assert len(agents) >= len(agent_map.keys())
     fetched_agents: Dict[str, AgentResponse] = {agent.system.id: agent for agent in agents}
@@ -52,7 +52,7 @@ def test_get_agents(agent_map: Dict[str, AgentResponse], user_manager: DeployedA
 
 @pytest.mark.order(4)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_unminting(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager) -> None:
+def test_unminting(agent_map: Dict[str, AgentResponse], user_manager: AgentManager) -> None:
     for agent_id in agent_map.keys():
         agent = user_manager.unmint_agent(agent_id)
         assert agent.system.state == "configured"
@@ -73,7 +73,7 @@ def test_messenger(agent_map: Dict[str, AgentResponse], user_messenger: Messenge
 
 @pytest.mark.order(6)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_updating(agent_registry: AgentRegistry, user_manager: DeployedAgentManager) -> None:
+def test_updating(agent_registry: AgentRegistry, user_manager: AgentManager) -> None:
     owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
     updated_agent_data = deepcopy(owner_agent_data)
     updated_agent_data.spec.metadata.name = "Updated Owner Agent"
@@ -87,6 +87,6 @@ def test_updating(agent_registry: AgentRegistry, user_manager: DeployedAgentMana
 
 @pytest.mark.order(-1)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_deletion(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager) -> None:
+def test_deletion(agent_map: Dict[str, AgentResponse], user_manager: AgentManager) -> None:
     for agent in agent_map.values():
         user_manager.delete_agent(agent.system.id)

--- a/tests/integration/test_as_user.py
+++ b/tests/integration/test_as_user.py
@@ -88,7 +88,7 @@ def test_updating(agent_registry: AgentRegistry, user_manager: AgentManager) -> 
 
 @pytest.mark.order(7)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_system_tag(agent_registry: AgentRegistry, user_manager: DeployedAgentManager) -> None:
+def test_system_tag(agent_registry: AgentRegistry, user_manager: AgentManager) -> None:
     owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
     config = AgentDeploymentConfiguration.from_env(env_prefix=owner_agent_data.metadata.labels["env_prefix"])
 
@@ -105,7 +105,7 @@ def test_system_tag(agent_registry: AgentRegistry, user_manager: DeployedAgentMa
 
 @pytest.mark.order(8)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_create_api_key(user_manager: DeployedAgentManager) -> None:
+def test_create_api_key(user_manager: AgentManager) -> None:
     expires_at = datetime.now(tz=timezone.utc) + timedelta(minutes=1)
     response = user_manager.create_api_key(expires_at)
 

--- a/tests/integration/test_as_user.py
+++ b/tests/integration/test_as_user.py
@@ -20,7 +20,7 @@ def test_registration(
 ) -> None:
     agent_data_objs = agent_registry.get_agents_of_types([AgentType.OWNER, AgentType.BASIC])
     for agent_data in agent_data_objs:
-        agent = user_manager.create_agent(agent_data.spec.metadata, agent_data.spec.configuration)
+        agent = user_manager.create_agent_from_data(agent_data)
         agent_map[agent.system.id] = agent
 
 

--- a/tests/integration/test_configurable.py
+++ b/tests/integration/test_configurable.py
@@ -39,7 +39,7 @@ def test_registration(
     agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: AgentManager
 ) -> None:
     configurable_agent_data = agent_registry.get_first_agent_of_type(AgentType.CONFIGURABLE)
-    agent = user_manager.create_agent(configurable_agent_data.spec.metadata, configurable_agent_data.spec.configuration)
+    agent = user_manager.create_agent_from_data(configurable_agent_data)
 
     assert agent.schemas.configuration is not None
     agent_map[agent.system.id] = agent

--- a/tests/integration/test_configurable.py
+++ b/tests/integration/test_configurable.py
@@ -7,15 +7,15 @@ from tests.integration.agent_registry import AgentRegistry, AgentType
 from tests.integration.agent_runner import AgentRunner, TestConfig
 
 from theoriq.api.v1alpha2 import AgentResponse
-from theoriq.api.v1alpha2.manage import AgentConfigurationError, DeployedAgentManager, VirtualAgentManager
+from theoriq.api.v1alpha2.manage import AgentConfigurationError, AgentManager
 from theoriq.api.v1alpha2.message import Messenger
 from theoriq.dialog import TextItemBlock
 from theoriq.types import AgentConfiguration, AgentMetadata
 
 
 @pytest.fixture()
-def virtual_manager() -> VirtualAgentManager:
-    return VirtualAgentManager.from_api_key(api_key=os.environ["THEORIQ_API_KEY"])
+def virtual_manager() -> AgentManager:
+    return AgentManager.from_api_key(api_key=os.environ["THEORIQ_API_KEY"])
 
 
 def assert_send_message_to_configurable_agent(
@@ -36,7 +36,7 @@ def assert_send_message_to_configurable_agent(
 @pytest.mark.order(1)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_registration(
-    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager
+    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: AgentManager
 ) -> None:
     configurable_agent_data = agent_registry.get_first_agent_of_type(AgentType.CONFIGURABLE)
     agent = user_manager.create_agent(configurable_agent_data.spec.metadata, configurable_agent_data.spec.configuration)
@@ -47,7 +47,7 @@ def test_registration(
 
 @pytest.mark.order(2)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_incorrect_configuration(agent_map: Dict[str, AgentResponse], virtual_manager: VirtualAgentManager) -> None:
+def test_incorrect_configuration(agent_map: Dict[str, AgentResponse], virtual_manager: AgentManager) -> None:
     deployed_agent = next(agent for agent in agent_map.values() if agent.configuration.is_deployed)
 
     metadata = AgentMetadata(
@@ -70,7 +70,7 @@ def test_incorrect_configuration(agent_map: Dict[str, AgentResponse], virtual_ma
 
 @pytest.mark.order(3)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_configuration(agent_map: Dict[str, AgentResponse], virtual_manager: VirtualAgentManager) -> None:
+def test_configuration(agent_map: Dict[str, AgentResponse], virtual_manager: AgentManager) -> None:
     deployed_agent = next(agent for agent in agent_map.values() if agent.configuration.is_deployed)
 
     configs = [TestConfig(text="test value", number=42), TestConfig(text="another value", number=-5)]
@@ -105,9 +105,7 @@ def test_messenger(agent_map: Dict[str, AgentResponse], user_messenger: Messenge
 
 @pytest.mark.order(5)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_incorrect_update_configuration(
-    agent_map: Dict[str, AgentResponse], virtual_manager: VirtualAgentManager
-) -> None:
+def test_incorrect_update_configuration(agent_map: Dict[str, AgentResponse], virtual_manager: AgentManager) -> None:
     virtual_agent = next(agent for agent in agent_map.values() if agent.configuration.is_virtual)
     deployed_agent_id = virtual_agent.configuration.ensure_virtual.agent_id
 
@@ -128,7 +126,7 @@ def test_incorrect_update_configuration(
 @pytest.mark.order(8)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_update_configuration(
-    agent_map: Dict[str, AgentResponse], virtual_manager: VirtualAgentManager, user_messenger: Messenger
+    agent_map: Dict[str, AgentResponse], virtual_manager: AgentManager, user_messenger: Messenger
 ) -> None:
     virtual_agent = next(agent for agent in agent_map.values() if agent.configuration.is_virtual)
     deployed_agent_id = virtual_agent.configuration.ensure_virtual.agent_id
@@ -147,7 +145,7 @@ def test_update_configuration(
 
 @pytest.mark.order(-1)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_deletion(agent_map: Dict[str, AgentResponse], virtual_manager: VirtualAgentManager) -> None:
+def test_deletion(agent_map: Dict[str, AgentResponse], virtual_manager: AgentManager) -> None:
     for agent in agent_map.values():
         virtual_manager.delete_agent(agent.system.id)
         print(f"Successfully deleted `{agent.system.id}`\n")

--- a/tests/integration/test_get_agents.py
+++ b/tests/integration/test_get_agents.py
@@ -1,5 +1,5 @@
 from theoriq.api.v1alpha2 import AgentResponse, ProtocolClient
-from theoriq.api.v1alpha2.manage import DeployedAgentManager
+from theoriq.api.v1alpha2.manage import AgentManager
 
 
 def test_get_agents_with_client() -> None:
@@ -12,7 +12,7 @@ def test_get_agents_with_client() -> None:
         assert agent.configuration.is_empty
 
 
-def test_get_agents_with_manager(user_manager: DeployedAgentManager) -> None:
+def test_get_agents_with_manager(user_manager: AgentManager) -> None:
     user_address = user_manager._biscuit_provider.address
 
     agents = user_manager.get_agents()

--- a/tests/integration/test_pub_sub.py
+++ b/tests/integration/test_pub_sub.py
@@ -43,7 +43,7 @@ def test_registration(
 ) -> None:
     agent_data_objs = agent_registry.get_agents_of_types([AgentType.OWNER, AgentType.BASIC])
     for agent_data in agent_data_objs:
-        agent = user_manager.create_agent(agent_data.spec.metadata, agent_data.spec.configuration)
+        agent = user_manager.create_agent_from_data(agent_data)
         agent_map[agent.system.id] = agent
 
 

--- a/tests/integration/test_pub_sub.py
+++ b/tests/integration/test_pub_sub.py
@@ -6,7 +6,7 @@ import pytest
 from tests.integration.agent_registry import AgentRegistry, AgentType
 
 from theoriq.api.v1alpha2 import AgentResponse
-from theoriq.api.v1alpha2.manage import DeployedAgentManager
+from theoriq.api.v1alpha2.manage import AgentManager
 from theoriq.api.v1alpha2.publish import Publisher, PublisherContext
 from theoriq.api.v1alpha2.subscribe import Subscriber
 from theoriq.biscuit import AgentAddress
@@ -39,7 +39,7 @@ def get_owner_agent_address(agent_registry: AgentRegistry, agent_map: Dict[str, 
 @pytest.mark.order(1)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_registration(
-    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager
+    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: AgentManager
 ) -> None:
     agent_data_objs = agent_registry.get_agents_of_types([AgentType.OWNER, AgentType.BASIC])
     for agent_data in agent_data_objs:
@@ -104,6 +104,6 @@ def test_subscribing_as_user(
 
 @pytest.mark.order(-1)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_deletion(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager) -> None:
+def test_deletion(agent_map: Dict[str, AgentResponse], user_manager: AgentManager) -> None:
     for agent in agent_map.values():
         user_manager.delete_agent(agent.system.id)

--- a/tests/integration/test_web3.py
+++ b/tests/integration/test_web3.py
@@ -5,7 +5,7 @@ import pytest
 from tests.integration.agent_registry import AgentRegistry, AgentType
 
 from theoriq.api.v1alpha2 import AgentResponse
-from theoriq.api.v1alpha2.manage import DeployedAgentManager
+from theoriq.api.v1alpha2.manage import AgentManager
 from theoriq.api.v1alpha2.schemas import AgentWeb3Transaction
 
 ETH_SEPOLIA_TX_HASH: Final[str] = "0xa8f64019914a952349d168340b5e7051c72bd722e60346defeb48bf99f5fdad1"
@@ -16,7 +16,7 @@ METADATA: Final[Dict[str, str]] = {"abc": "xyz"}
 @pytest.mark.order(1)
 @pytest.mark.usefixtures("agent_flask_apps")
 def test_registration_owner(
-    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager
+    agent_registry: AgentRegistry, agent_map: Dict[str, AgentResponse], user_manager: AgentManager
 ) -> None:
     owner_agent_data = agent_registry.get_first_agent_of_type(AgentType.OWNER)
     agent = user_manager.create_agent(owner_agent_data.spec.metadata, owner_agent_data.spec.configuration)
@@ -25,7 +25,7 @@ def test_registration_owner(
 
 @pytest.mark.order(2)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_post_web3_transaction_as_user(user_manager: DeployedAgentManager) -> None:
+def test_post_web3_transaction_as_user(user_manager: AgentManager) -> None:
     with pytest.raises(httpx.HTTPStatusError) as e:
         user_manager.post_web3_transaction(ETH_SEPOLIA_TX_HASH, ETH_SEPOLIA_CHAIN_ID)
     assert e.value.response.status_code == 401
@@ -33,13 +33,13 @@ def test_post_web3_transaction_as_user(user_manager: DeployedAgentManager) -> No
 
 @pytest.mark.order(3)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_post_web3_transaction(owner_manager: DeployedAgentManager) -> None:
+def test_post_web3_transaction(owner_manager: AgentManager) -> None:
     owner_manager.post_web3_transaction(tx_hash=ETH_SEPOLIA_TX_HASH, chain_id=ETH_SEPOLIA_CHAIN_ID, metadata=METADATA)
 
 
 @pytest.mark.order(4)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_get_web3_transaction(owner_manager: DeployedAgentManager) -> None:
+def test_get_web3_transaction(owner_manager: AgentManager) -> None:
     tx = owner_manager.get_web3_transaction(ETH_SEPOLIA_TX_HASH)
 
     assert isinstance(tx, AgentWeb3Transaction)
@@ -50,7 +50,7 @@ def test_get_web3_transaction(owner_manager: DeployedAgentManager) -> None:
 
 @pytest.mark.order(5)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_get_web3_transactions_as_user(user_manager: DeployedAgentManager) -> None:
+def test_get_web3_transactions_as_user(user_manager: AgentManager) -> None:
     transactions = user_manager.get_web3_transactions()
 
     assert len(transactions) >= 1
@@ -59,7 +59,7 @@ def test_get_web3_transactions_as_user(user_manager: DeployedAgentManager) -> No
 
 @pytest.mark.order(6)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_get_web3_transactions(owner_manager: DeployedAgentManager) -> None:
+def test_get_web3_transactions(owner_manager: AgentManager) -> None:
     transactions = owner_manager.get_web3_transactions()
 
     assert len(transactions) >= 1
@@ -68,6 +68,6 @@ def test_get_web3_transactions(owner_manager: DeployedAgentManager) -> None:
 
 @pytest.mark.order(-1)
 @pytest.mark.usefixtures("agent_flask_apps")
-def test_deletion_owner(agent_map: Dict[str, AgentResponse], user_manager: DeployedAgentManager) -> None:
+def test_deletion_owner(agent_map: Dict[str, AgentResponse], user_manager: AgentManager) -> None:
     for agent in agent_map.values():
         user_manager.delete_agent(agent.system.id)

--- a/theoriq/api/v1alpha2/manage.py
+++ b/theoriq/api/v1alpha2/manage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import abc
 import json
 import uuid
 from typing import Any, Dict, List, Optional
@@ -13,8 +12,18 @@ from . import AgentResponse, ProtocolClient
 from .protocol.biscuit_provider import BiscuitProvider, BiscuitProviderFactory
 
 
-class AgentManagerBase(abc.ABC):
-    """Base class for agent manager."""
+class AgentConfigurationError(Exception):
+    def __init__(self, message: str, agent: AgentResponse, original_exception: Exception) -> None:
+        self.message = message
+        self.agent = agent
+        self.original_exception = original_exception
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class AgentManager:
+    """Provides capabilities to manage Theoriq agents."""
 
     def __init__(self, biscuit_provider: BiscuitProvider, client: Optional[ProtocolClient] = None) -> None:
         self._client = client or ProtocolClient.from_env()
@@ -28,9 +37,13 @@ class AgentManagerBase(abc.ABC):
         biscuit = self._biscuit_provider.get_biscuit()
         return self._client.get_agent(agent_id=agent_id, biscuit=biscuit)
 
-    @abc.abstractmethod
     def create_agent(self, metadata: AgentMetadata, configuration: AgentConfiguration) -> AgentResponse:
-        pass
+        agent = self._create_agent(metadata=metadata, configuration=configuration)
+
+        if configuration.deployment is not None:
+            return agent  # deployed agent
+        # virtual agent
+        return self._try_configure_agent(agent, f"Agent {agent.system.id} created but failed to configure")
 
     def _create_agent(self, metadata: AgentMetadata, configuration: AgentConfiguration) -> AgentResponse:
         payload_dict = {"metadata": metadata.to_dict(), "configuration": configuration.to_dict()}
@@ -38,14 +51,35 @@ class AgentManagerBase(abc.ABC):
         biscuit = self._biscuit_provider.get_biscuit()
         return self._client.post_agent(biscuit=biscuit, content=payload)
 
-    @abc.abstractmethod
+    def _configure_agent(self, *, agent_id: str, configuration_hash: str) -> AgentResponse:
+        theoriq_request = TheoriqRequest.from_body(
+            body=configuration_hash.encode("utf-8"),
+            from_addr=self._biscuit_provider.address,
+            to_addr=agent_id,
+        )
+        theoriq_biscuit = self._biscuit_provider.get_request_biscuit(request_id=uuid.uuid4(), facts=[theoriq_request])
+        return self._client.post_configure(biscuit=theoriq_biscuit, to_addr=agent_id)
+
+    def _try_configure_agent(self, agent: AgentResponse, error_message: str) -> AgentResponse:
+        try:
+            return self._configure_agent(
+                agent_id=agent.system.id, configuration_hash=agent.configuration.ensure_virtual.configuration_hash
+            )
+        except Exception as e:
+            raise AgentConfigurationError(message=error_message, agent=agent, original_exception=e) from e
+
     def update_agent(
         self,
         agent_id: str,
         metadata: Optional[AgentMetadata] = None,
         configuration: Optional[AgentConfiguration] = None,
     ) -> AgentResponse:
-        pass
+        agent = self._update_agent(agent_id=agent_id, metadata=metadata, configuration=configuration)
+
+        if configuration is None or configuration.deployment is not None:
+            return agent  # deployed agent
+        # virtual agent
+        return self._try_configure_agent(agent, f"Agent {agent.system.id} updated but failed to configure")
 
     def _update_agent(
         self,
@@ -79,62 +113,3 @@ class AgentManagerBase(abc.ABC):
     @classmethod
     def from_env(cls, env_prefix: str = "") -> Self:
         return cls(biscuit_provider=BiscuitProviderFactory.from_env(env_prefix=env_prefix))
-
-
-class DeployedAgentManager(AgentManagerBase):
-    """Provides capabilities to manage deployed agents."""
-
-    def create_agent(self, metadata: AgentMetadata, configuration: AgentConfiguration) -> AgentResponse:
-        return self._create_agent(metadata=metadata, configuration=configuration)
-
-    def update_agent(
-        self,
-        agent_id: str,
-        metadata: Optional[AgentMetadata] = None,
-        configuration: Optional[AgentConfiguration] = None,
-    ) -> AgentResponse:
-        return self._update_agent(agent_id=agent_id, metadata=metadata, configuration=configuration)
-
-
-class AgentConfigurationError(Exception):
-    def __init__(self, message: str, agent: AgentResponse, original_exception: Exception) -> None:
-        self.message = message
-        self.agent = agent
-        self.original_exception = original_exception
-
-    def __str__(self) -> str:
-        return self.message
-
-
-class VirtualAgentManager(AgentManagerBase):
-    """Provides capabilities to manage virtual agents."""
-
-    def create_agent(self, metadata: AgentMetadata, configuration: AgentConfiguration) -> AgentResponse:
-        agent = self._create_agent(metadata=metadata, configuration=configuration)
-        return self.try_configure_agent(agent, error_message=f"Agent {agent.system.id} created but failed to configure")
-
-    def update_agent(
-        self,
-        agent_id: str,
-        metadata: Optional[AgentMetadata] = None,
-        configuration: Optional[AgentConfiguration] = None,
-    ) -> AgentResponse:
-        agent = self._update_agent(agent_id=agent_id, metadata=metadata, configuration=configuration)
-        return self.try_configure_agent(agent, error_message=f"Agent {agent.system.id} updated but failed to configure")
-
-    def configure_agent(self, *, agent_id: str, configuration_hash: str) -> AgentResponse:
-        theoriq_request = TheoriqRequest.from_body(
-            body=configuration_hash.encode("utf-8"),
-            from_addr=self._biscuit_provider.address,
-            to_addr=agent_id,
-        )
-        theoriq_biscuit = self._biscuit_provider.get_request_biscuit(request_id=uuid.uuid4(), facts=[theoriq_request])
-        return self._client.post_configure(biscuit=theoriq_biscuit, to_addr=agent_id)
-
-    def try_configure_agent(self, agent: AgentResponse, error_message: str) -> AgentResponse:
-        try:
-            return self.configure_agent(
-                agent_id=agent.system.id, configuration_hash=agent.configuration.ensure_virtual.configuration_hash
-            )
-        except Exception as e:
-            raise AgentConfigurationError(message=error_message, agent=agent, original_exception=e) from e

--- a/theoriq/api/v1alpha2/manage.py
+++ b/theoriq/api/v1alpha2/manage.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 from typing_extensions import Self
 
 from ...biscuit import TheoriqRequest
-from ...types import AgentConfiguration, AgentMetadata
+from ...types import AgentConfiguration, AgentDataObject, AgentMetadata
 from . import AgentResponse, ProtocolClient
 from .protocol.biscuit_provider import BiscuitProvider, BiscuitProviderFactory
 
@@ -45,6 +45,9 @@ class AgentManager:
         # virtual agent
         return self._try_configure_agent(agent, f"Agent {agent.system.id} created but failed to configure")
 
+    def create_agent_from_data(self, agent_data: AgentDataObject) -> AgentResponse:
+        return self.create_agent(agent_data.spec.metadata, agent_data.spec.configuration)
+
     def _create_agent(self, metadata: AgentMetadata, configuration: AgentConfiguration) -> AgentResponse:
         payload_dict = {"metadata": metadata.to_dict(), "configuration": configuration.to_dict()}
         payload = json.dumps(payload_dict).encode("utf-8")
@@ -80,6 +83,11 @@ class AgentManager:
             return agent  # deployed agent
         # virtual agent
         return self._try_configure_agent(agent, f"Agent {agent.system.id} updated but failed to configure")
+
+    def update_agent_from_data(self, agent_id: str, agent_data: AgentDataObject) -> AgentResponse:
+        return self.update_agent(
+            agent_id, metadata=agent_data.spec.metadata, configuration=agent_data.spec.maybe_configuration
+        )
 
     def _update_agent(
         self,


### PR DESCRIPTION
- Introduce single `AgentManager` that determines whether configuration is needed based on `configuration.virtual is not None` as opposed to have separate `DeployedAgentManager` and `VirtualAgentManager`
- Add helper methods to create/update agent from `AgentDataObject`