### PR TITLE
Move last_item functionality from ExecuteRequestBody to Dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The `ExecuteRequestBody` class represents the body of an execution request. It c
 
 ***Methods:***
 
-# TODO: need to update
 - `last_item`: Returns the last `DialogItem` based on the timestamp.
 - `last_item_from`: Filters and returns the last `DialogItem` from a specific source type: either the `user` or an `agent`.
 

--- a/theoriq/api/v1alpha2/schemas/request.py
+++ b/theoriq/api/v1alpha2/schemas/request.py
@@ -32,3 +32,17 @@ class ExecuteRequestBody(BaseModel):
 
     configuration: Optional[Configuration] = None
     dialog: Dialog
+
+    @property
+    def last_item(self) -> Optional[DialogItem]:
+        return self.dialog.last_item
+
+    @property
+    def last_text(self) -> str:
+        return self.dialog.last_text
+
+    def last_item_from(self, source_type: SourceType) -> Optional[DialogItem]:
+        return self.dialog.last_item_from(source_type)
+
+    def last_item_predicate(self, predicate: DialogItemPredicate) -> Optional[DialogItem]:
+        return self.dialog.last_item_predicate(predicate)

--- a/theoriq/dialog/dialog.py
+++ b/theoriq/dialog/dialog.py
@@ -204,7 +204,7 @@ class Dialog(BaseModel):
         """
         if len(self.items) == 0:
             return None
-        # Finds and returns the dialog item with the latest timestamp.
+
         return max(self.items, key=lambda obj: obj.timestamp)
 
     @property
@@ -235,7 +235,7 @@ class Dialog(BaseModel):
             Optional[DialogItem]: The dialog item with the most recent timestamp from the specified source type,
                                   or None if no items match the source type.
         """
-        # Filters items by source type and finds the one with the latest timestamp.
+
         return self.last_item_predicate(lambda item: item.source_type == source_type)
 
     def last_item_predicate(self, predicate: DialogItemPredicate) -> Optional[DialogItem]:
@@ -250,7 +250,6 @@ class Dialog(BaseModel):
                                        or None if no items match the predicate.
         """
 
-        # Filters items matching the given predicate and finds the one with the latest timestamp.
         items = (item for item in self.items if predicate(item))
         return max(items, key=lambda obj: obj.timestamp) if items else None
 


### PR DESCRIPTION
Move `last_item_*` functionality from `ExecuteRequestBody` to `Dialog`, as we currently can't do for example `Dialog.last_item`
Keep them in `ExecuteRequestBody` as thin wrappers for backward compatibility