### PR TITLE
Adding proposed actions message block

### DIFF
--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,0 +1,71 @@
+from typing import Final, Sequence
+
+from theoriq.biscuit import AgentAddress
+from theoriq.dialog import ActionItem, ActionsItemBlock, Dialog, DialogItem
+from theoriq.types import SourceType
+
+USER_ADDRESS: Final[str] = "0x1F32Bc2B1Ace25D762E22888a71C7eC0799D379f"
+RANDOM_AGENT_ADDRESS: Final[str] = str(AgentAddress.random())
+
+
+dialog_actions_payload = {
+    "items": [
+        {
+            "sourceType": str(SourceType.User),
+            "source": USER_ADDRESS,
+            "timestamp": "2025-06-30T12:00:00Z",
+            "blocks": [
+                {"data": {"text": "Choose an option"}, "type": "text"},
+            ],
+        },
+        {
+            "sourceType": str(SourceType.Agent),
+            "source": RANDOM_AGENT_ADDRESS,
+            "timestamp": "2025-06-30T12:00:02Z",
+            "blocks": [
+                {
+                    "type": "actions",
+                    "key": "proposal-1",
+                    "data": {
+                        "items": [
+                            {"id": "approve", "label": "Approve", "description": "Approve transfer"},
+                            {"id": "reject", "label": "Reject"},
+                        ]
+                    },
+                }
+            ],
+        },
+    ]
+}
+
+
+def test_actions_block_deserialization_roundtrip() -> None:
+    """The payload should parse into Dialog and then round-trip back unchanged."""
+    d: Dialog = Dialog.model_validate(dialog_actions_payload)
+
+    # Agent message should contain an ActionsItemBlock
+    assert isinstance(d.items[1].blocks[0], ActionsItemBlock)
+    block: ActionsItemBlock = d.items[1].blocks[0]  # type: ignore[assignment]
+
+    # First action should be the approve button
+    assert block.data[0].id == "approve"
+    assert block.data[0].label == "Approve"
+
+    # Round-trip: model_dump() then validate again should produce equivalent structure
+    dumped = d.model_dump(mode="python")
+    reparsed = Dialog.model_validate(dumped).model_dump(mode="python")
+    assert dumped == reparsed
+
+
+def test_new_actions_helper() -> None:
+    """`DialogItem.new_actions` should create a correct Actions block."""
+    actions: Sequence[ActionItem] = [
+        ActionItem(id="yes", label="Yes"),
+        ActionItem(id="no", label="No"),
+    ]
+    item: DialogItem = DialogItem.new_actions(source=RANDOM_AGENT_ADDRESS, actions=actions, key="q1")
+
+    assert isinstance(item.blocks[0], ActionsItemBlock)
+    block: ActionsItemBlock = item.blocks[0]  # type: ignore[assignment]
+    assert len(block.data) == 2
+    assert block.find("yes") is not None

--- a/theoriq/dialog/__init__.py
+++ b/theoriq/dialog/__init__.py
@@ -9,5 +9,6 @@ from .router import RouteItem, RouterItemBlock
 from .runtime_error import ErrorItem, ErrorItemBlock
 from .text import TextItem, TextItemBlock
 from .web3 import Web3ProposedTxBlock, Web3ProposedTxItem, Web3SignedTxBlock, Web3SignedTxItem
+from .actions import ActionItem, ActionsItemBlock
 
 from .dialog import Dialog, DialogItem, DialogItemPredicate, format_source_and_blocks

--- a/theoriq/dialog/actions.py
+++ b/theoriq/dialog/actions.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence
+
+from .item_block import BaseData, ItemBlock
+
+
+class ActionItem(BaseData):
+    """A single user-selectable action such as a button.
+
+    Attributes
+    ----------
+    id: str
+        A unique identifier within the surrounding ActionsItemBlock. Will be echoed back when the
+        user selects the action.
+    label: str
+        Human-readable label for UI display (e.g. button text).
+    description: Optional[str]
+        Longer explanation or tooltip. Optional so CLI renderings can ignore it.
+    payload: Optional[Dict[str, Any]]
+        Arbitrary data for the consumer to echo back (e.g. a router target, parameters, etc.).
+    """
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        label: str,
+        description: Optional[str] = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.id = id
+        self.label = label
+        self.description = description
+        self.payload = payload
+
+    @classmethod
+    def from_dict(cls, values: Dict[str, Any]) -> "ActionItem":
+        return cls(
+            id=values["id"],
+            label=values["label"],
+            description=values.get("description"),
+            payload=values.get("payload"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {"id": self.id, "label": self.label}
+        if self.description is not None:
+            result["description"] = self.description
+        if self.payload is not None:
+            result["payload"] = self.payload
+        return result
+
+    def to_str(self) -> str:  # pragma: no cover – only used for debug / CLI
+        """Human-readable representation used by Dialog.format_as_markdown()."""
+        result = f"- {self.label} (id: {self.id})"
+        if self.description:
+            result += f" – {self.description}"
+        return result
+
+    def __str__(self) -> str:
+        return f"ActionItem(id={self.id}, label={self.label})"
+
+
+class ActionsItemBlock(ItemBlock[Sequence[ActionItem]]):
+    """A block containing a list of available actions."""
+
+    def __init__(
+        self,
+        actions: Sequence[ActionItem],
+        *,
+        key: Optional[str] = None,
+        reference: Optional[str] = None,
+    ) -> None:
+        super().__init__(block_type=self.block_type(), data=actions, key=key, reference=reference)
+
+    # ---------------------------------------------------------------------
+    # ItemBlock interface helpers
+    # ---------------------------------------------------------------------
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Dict[str, Any],
+        block_type: str,
+        block_key: Optional[str] = None,
+        block_ref: Optional[str] = None,
+    ) -> "ActionsItemBlock":
+        cls.raise_if_not_valid(block_type=block_type, expected=cls.block_type())
+        items = data.get("items", [])
+        return cls(actions=[ActionItem.from_dict(it) for it in items], key=block_key, reference=block_ref)
+
+    @staticmethod
+    def block_type() -> str:
+        return "actions"
+
+    @staticmethod
+    def is_valid(block_type: str) -> bool:
+        return block_type == ActionsItemBlock.block_type()
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+    def find(self, action_id: str) -> Optional[ActionItem]:
+        """Return an action by its *id* or None if not found."""
+        return next((a for a in self.data if a.id == action_id), None)

--- a/theoriq/dialog/dialog.py
+++ b/theoriq/dialog/dialog.py
@@ -17,6 +17,7 @@ from .router import RouteItem, RouterItemBlock
 from .runtime_error import ErrorItemBlock
 from .text import TextItemBlock
 from .web3 import Web3ProposedTxBlock, Web3SignedTxBlock
+from .actions import ActionItem, ActionsItemBlock
 
 BLOCK_CLASSES: Final[List[Type[ItemBlock]]] = [
     CodeItemBlock,
@@ -29,6 +30,7 @@ BLOCK_CLASSES: Final[List[Type[ItemBlock]]] = [
     TextItemBlock,
     Web3ProposedTxBlock,
     Web3SignedTxBlock,
+    ActionsItemBlock,
 ]
 BLOCK_CLASSES_MAP: Mapping[str, Type[ItemBlock]] = {block_cls.block_type(): block_cls for block_cls in BLOCK_CLASSES}
 
@@ -165,6 +167,12 @@ class DialogItem:
     @classmethod
     def new_route(cls, source: str, route: str, score: float) -> DialogItem:
         return DialogItem.new(source=source, blocks=[RouterItemBlock([RouteItem(route, score)])])
+
+    @classmethod
+    def new_actions(cls, source: str, actions: Sequence[ActionItem], key: Optional[str] = None) -> DialogItem:
+        """Create a DialogItem that proposes a list of actions to the user."""
+        block = ActionsItemBlock(actions, key=key)
+        return DialogItem.new(source=source, blocks=[block])
 
     def __str__(self) -> str:
         source_str = f"{self.source[:6]}...{self.source[-4:]}"


### PR DESCRIPTION
Add support for “actions” message type:
* New ActionItem / ActionsItemBlock for proposing selectable actions
* Registered in Dialog, plus DialogItem.new_actions() helper
* Unit-tests + ruff/black clean