### PR TITLE
Make custom_type in CustomData optional

### DIFF
--- a/theoriq/dialog/custom_items.py
+++ b/theoriq/dialog/custom_items.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, Dict
+from typing import Annotated, Any, Dict, Optional
 
 from pydantic import Field, field_validator, model_validator
 
@@ -9,7 +9,7 @@ from .block import BaseData, BlockBase
 
 class CustomData(BaseData):
     data: Dict[str, Any]
-    custom_type: str
+    custom_type: Optional[str] = None
 
 
 class CustomBlock(BlockBase[CustomData, Annotated[str, Field(pattern="custom:(.*)?")]]):


### PR DESCRIPTION
Changed the custom_type field in CustomData to be Optional[str] with a default of None. This allows instances of CustomData to omit the custom_type value if not needed.